### PR TITLE
Remove hard-coded separators from database files

### DIFF
--- a/cmds/MTCA-EVR-300_standalone_bi-aptm.cmd
+++ b/cmds/MTCA-EVR-300_standalone_bi-aptm.cmd
@@ -13,23 +13,24 @@ epicsEnvSet("LOCATION","")
 
 epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 
-epicsEnvSet("IOC", "TESTIOC")
-epicsEnvSet("DEV1", "EVR1")
+epicsEnvSet("IOC", "TESTIOC:")
+epicsEnvSet("EVR", "EVR1")
+epicsEnvSet("DEV1", "$(EVR):")
 
 epicsEnvSet("MainEvtCODE" "14")
 epicsEnvSet("HeartBeatEvtCODE"   "122")
 epicsEnvSet("ESSEvtClockRate"  "88.0525")
 
 ### Register the EVR with the IOC and load the database ###
-mrmEvrSetupPCI("$(DEV1)",  "06:00.0")
-dbLoadRecords("evr-mtca-300u-ess.db","EVR=$(DEV1), SYS=$(IOC), D=$(DEV1), FEVT=$(ESSEvtClockRate)")
+mrmEvrSetupPCI("$(EVR)",  "06:00.0")
+dbLoadRecords("evr-mtca-300u-ess.db","EVR=$(EVR), SYS=$(IOC), D=$(DEV1), FEVT=$(ESSEvtClockRate)")
 
 ### Needed with software timestamp source w/o RT thread scheduling ###
 var evrMrmTimeNSOverflowThreshold 100000
 
 
 # iocStats
-# dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC):IocStats")
+# dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC)IocStats")
 
 
 
@@ -39,47 +40,47 @@ iocInit()
 # dbl > "${IOC}_PVs.list"
 
 ### Get current time from system clock ###
-dbpf $(IOC)-$(DEV1):TimeSrc-Sel 2
+dbpf $(IOC)$(DEV1)TimeSrc-Sel 2
 
 ### Set up the prescaler that will trigger the sequencer at 14 Hz ###
-dbpf $(IOC)-$(DEV1):PS0-Div-SP 6289424 # in standalone mode because real freq from synthsiezer is 88.05194802 MHz, otherwise 6289464
+dbpf $(IOC)$(DEV1)PS0-Div-SP 6289424 # in standalone mode because real freq from synthsiezer is 88.05194802 MHz, otherwise 6289464
 
 ### Set up the sequencer ###
-dbpf $(IOC)-$(DEV1):SoftSeq0-RunMode-Sel 0 # normal mode, rearm after finish
-dbpf $(IOC)-$(DEV1):SoftSeq0-TrigSrc-2-Sel 2 # trigger the sequence from prescaler 0
-dbpf $(IOC)-$(DEV1):SoftSeq0-TsResolution-Sel 2 # select us as the units of the timestamp array of the seuqncer
-dbpf $(IOC)-$(DEV1):SoftSeq0-Load-Cmd 1
-dbpf $(IOC)-$(DEV1):SoftSeq0-Enable-Cmd 1
+dbpf $(IOC)$(DEV1)SoftSeq0-RunMode-Sel 0 # normal mode, rearm after finish
+dbpf $(IOC)$(DEV1)SoftSeq0-TrigSrc-2-Sel 2 # trigger the sequence from prescaler 0
+dbpf $(IOC)$(DEV1)SoftSeq0-TsResolution-Sel 2 # select us as the units of the timestamp array of the seuqncer
+dbpf $(IOC)$(DEV1)SoftSeq0-Load-Cmd 1
+dbpf $(IOC)$(DEV1)SoftSeq0-Enable-Cmd 1
 
 ### Trigger backplane trigger line X at 14 Hz ###
-# dbpf $(IOC)-$(DEV1):DlyGen0-Evt-Trig0-SP $(MainEvtCODE)
-# dbpf $(IOC)-$(DEV1):DlyGen0-Width-SP 1000 # time in us, as selected with $(IOC)-$(DEV1):SoftSeq0-TsResolution-Sel
-# dbpf $(IOC)-$(DEV1):OutBackX-Src-SP 0 # trigger from delay generator 0
+# dbpf $(IOC)$(DEV1)DlyGen0-Evt-Trig0-SP $(MainEvtCODE)
+# dbpf $(IOC)$(DEV1)DlyGen0-Width-SP 1000 # time in us, as selected with $(IOC)$(DEV1)SoftSeq0-TsResolution-Sel
+# dbpf $(IOC)$(DEV1)OutBackX-Src-SP 0 # trigger from delay generator 0
 
 ### Send event clock over backplane clock line TCLKB, MCH should be configured to send the clock back to the AMCs over TCLKA ###
- dbpf $(IOC)-$(DEV1):OutTCLKB-Src-SP 63
- dbpf $(IOC)-$(DEV1):OutTCLKB-Ena-Sel 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pwr-Sel 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BF 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BE 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BD 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BC 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BB 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BA 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B9 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B8 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B7 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B6 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B5 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B4 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B3 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B2 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B1 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B0 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low16_31-SP.BF 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low16_31-SP.BE 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low16_31-SP.BD 1
- dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low16_31-SP.BC 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Src-SP 63
+ dbpf $(IOC)$(DEV1)OutTCLKB-Ena-Sel 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pwr-Sel 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BF 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BE 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BD 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BC 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BB 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BA 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B9 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B8 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B7 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B6 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B5 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B4 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B3 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B2 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B1 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B0 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low16_31-SP.BF 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low16_31-SP.BE 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low16_31-SP.BD 1
+ dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low16_31-SP.BC 1
 
 ### Run the script that configures the events and timestamp of the sequence ###
 system("/bin/sh ./configure_sequencer_14Hz.sh $(IOC) $(DEV1)")

--- a/cmds/MTCA-EVR-300_standalone_template.cmd
+++ b/cmds/MTCA-EVR-300_standalone_template.cmd
@@ -13,8 +13,9 @@ epicsEnvSet("LOCATION","")
 
 epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 
-epicsEnvSet("IOC", "TESTIOC")
-epicsEnvSet("DEV1", "EVR1")
+epicsEnvSet("IOC", "TESTIOC:")
+epicsEnvSet("EVR", "EVR1")
+epicsEnvSet("DEV1", "$(EVR):")
 
 epicsEnvSet("MainEvtCODE" "14")
 epicsEnvSet("HeartBeatEvtCODE"   "122")
@@ -22,14 +23,14 @@ epicsEnvSet("ESSEvtClockRate"  "88.0525")
 
 ### Register the EVR with the IOC and load the database ###
 mrmEvrSetupPCI("$(DEV1)",  "06:00.0")
-dbLoadRecords("evr-mtca-300u-ess.db","EVR=$(DEV1), SYS=$(IOC), D=$(DEV1), FEVT=$(ESSEvtClockRate)")
+dbLoadRecords("evr-mtca-300u-ess.db","EVR=$(EVR), SYS=$(IOC), D=$(DEV1), FEVT=$(ESSEvtClockRate)")
 
 ### Needed with software timestamp source w/o RT thread scheduling ###
 var evrMrmTimeNSOverflowThreshold 100000
 
 
 # iocStats
-# dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC):IocStats")
+# dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC)IocStats")
 
 
 
@@ -39,50 +40,50 @@ iocInit()
 # dbl > "${IOC}_PVs.list"
 
 ### Get current time from system clock ###
-dbpf $(IOC)-$(DEV1):TimeSrc-Sel "Sys. Clock"
+dbpf $(IOC)$(DEV1)TimeSrc-Sel "Sys. Clock"
 
 ### Set delay compensation to 70 ns, needed to avoid timesptamp issue ###
-dbpf $(IOC)-$(DEV1):DC-Tgt-SP 70
+dbpf $(IOC)$(DEV1)DC-Tgt-SP 70
 
 ### Set up the prescaler that will trigger the sequencer at 14 Hz ###
-dbpf $(IOC)-$(DEV1):PS0-Div-SP 6289424 # in standalone mode because real freq from synthsiezer is 88.05194802 MHz, otherwise 6289464
+dbpf $(IOC)$(DEV1)PS0-Div-SP 6289424 # in standalone mode because real freq from synthsiezer is 88.05194802 MHz, otherwise 6289464
 
 ### Set up the sequencer ###
-dbpf $(IOC)-$(DEV1):SoftSeq0-RunMode-Sel "Normal"
-dbpf $(IOC)-$(DEV1):SoftSeq0-TrigSrc-2-Sel "Prescaler 0"
-dbpf $(IOC)-$(DEV1):SoftSeq0-TsResolution-Sel "uSec"
-dbpf $(IOC)-$(DEV1):SoftSeq0-Load-Cmd 1
-dbpf $(IOC)-$(DEV1):SoftSeq0-Enable-Cmd 1
+dbpf $(IOC)$(DEV1)SoftSeq0-RunMode-Sel "Normal"
+dbpf $(IOC)$(DEV1)SoftSeq0-TrigSrc-2-Sel "Prescaler 0"
+dbpf $(IOC)$(DEV1)SoftSeq0-TsResolution-Sel "uSec"
+dbpf $(IOC)$(DEV1)SoftSeq0-Load-Cmd 1
+dbpf $(IOC)$(DEV1)SoftSeq0-Enable-Cmd 1
 
 ### Trigger backplane trigger line X at 14 Hz ###
-# dbpf $(IOC)-$(DEV1):DlyGen0-Evt-Trig0-SP $(MainEvtCODE)
-# dbpf $(IOC)-$(DEV1):DlyGen0-Width-SP 1000 # time in us
-# dbpf $(IOC)-$(DEV1):OutBackX-Src-SP 0 # trigger from delay generator 0
+# dbpf $(IOC)$(DEV1)DlyGen0-Evt-Trig0-SP $(MainEvtCODE)
+# dbpf $(IOC)$(DEV1)DlyGen0-Width-SP 1000 # time in us
+# dbpf $(IOC)$(DEV1)OutBackX-Src-SP 0 # trigger from delay generator 0
 
 ### Send event clock over backplane clock line TCLKB, MCH should be configured to send the clock back to the AMCs over TCLKA ###
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Src-SP 63
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Ena-Sel 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pwr-Sel 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BF 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BE 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BD 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BC 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BB 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BA 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B9 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B8 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B7 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B6 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B5 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B4 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B3 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B2 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B1 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B0 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low16_31-SP.BF 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low16_31-SP.BE 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low16_31-SP.BD 1
-# dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low16_31-SP.BC 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Src-SP 63
+# dbpf $(IOC)$(DEV1)OutTCLKB-Ena-Sel 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pwr-Sel 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BF 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BE 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BD 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BC 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BB 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BA 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B9 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B8 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B7 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B6 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B5 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B4 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B3 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B2 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B1 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B0 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low16_31-SP.BF 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low16_31-SP.BE 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low16_31-SP.BD 1
+# dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low16_31-SP.BC 1
 
 ### Run the script that configures the events and timestamp of the sequence ###
 system("/bin/sh ./configure_sequencer_14Hz.sh $(IOC) $(DEV1)")

--- a/cmds/TCLKB.cmd
+++ b/cmds/TCLKB.cmd
@@ -12,15 +12,16 @@ epicsEnvSet("LOCATION","ICS Tuna Lab")
 
 epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 
-epicsEnvSet("IOC", "TCLKB")
-epicsEnvSet("DEV1", "EVR1")
+epicsEnvSet("IOC", "TCLKB:")
+epicsEnvSet("EVR", "EVR1")
+epicsEnvSet("DEV1", "$(EVR):")
 
 epicsEnvSet("MainEvtCODE" "14")
 epicsEnvSet("HeartBeatEvtCODE"   "122")
 epicsEnvSet("ESSEvtClockRate"  "88.0525")
 
-mrmEvrSetupPCI("$(DEV1)",  "06:00.0")
-dbLoadRecords("evr-mtca-300u-ess.db","EVR=$(DEV1), SYS=$(IOC), D=$(DEV1), FEVT=$(ESSEvtClockRate)")
+mrmEvrSetupPCI("$(EVR)",  "06:00.0")
+dbLoadRecords("evr-mtca-300u-ess.db","EVR=$(EVR), SYS=$(IOC), D=$(DEV1), FEVT=$(ESSEvtClockRate)")
 
 
 # needed with software timestamp source w/o RT thread scheduling
@@ -37,29 +38,29 @@ iocInit()
 
 dbl > "${IOC}_PVs.list"
 
-dbpf $(IOC)-$(DEV1):OutTCLKB-Src-SP 63
-dbpf $(IOC)-$(DEV1):OutTCLKB-Ena-Sel 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pwr-Sel 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Src-SP 63
+dbpf $(IOC)$(DEV1)OutTCLKB-Ena-Sel 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pwr-Sel 1
 
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BF 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BE 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BD 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BC 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BB 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.BA 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B9 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B8 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B7 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B6 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B5 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B4 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B3 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B2 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B1 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low00_15-SP.B0 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BF 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BE 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BD 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BC 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BB 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.BA 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B9 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B8 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B7 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B6 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B5 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B4 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B3 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B2 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B1 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low00_15-SP.B0 1
 
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low16_31-SP.BF 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low16_31-SP.BE 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low16_31-SP.BD 1
-dbpf $(IOC)-$(DEV1):OutTCLKB-Pat-Low16_31-SP.BC 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low16_31-SP.BF 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low16_31-SP.BE 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low16_31-SP.BD 1
+dbpf $(IOC)$(DEV1)OutTCLKB-Pat-Low16_31-SP.BC 1
 

--- a/cmds/configure_sequencer_14Hz.sh
+++ b/cmds/configure_sequencer_14Hz.sh
@@ -2,11 +2,11 @@
 # All values in us
 
 # Event code 14 (14 Hz), 127 is the end of sequence
-caput -a $1-$2:SoftSeq0-EvtCode-SP 2 14 127
+caput -a $1$2SoftSeq0-EvtCode-SP 2 14 127
 
 # Defining time at which the event codes are sent in us
-caput -a $1-$2:SoftSeq0-Timestamp-SP 2 0 1
+caput -a $1$2SoftSeq0-Timestamp-SP 2 0 1
 
 # Commit the sequence to HW
-caput $1-$2:SoftSeq0-Commit-Cmd 1
+caput $1$2SoftSeq0-Commit-Cmd 1
 

--- a/cmds/cpci230evg.cmd
+++ b/cmds/cpci230evg.cmd
@@ -10,8 +10,9 @@ epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 
 epicsEnvSet("AUTOSAVE", "/home/timinguser/autosave")
 
-epicsEnvSet("IOC", "FREIA-CPCI")
-epicsEnvSet("DEV1", "EVG0")
+epicsEnvSet("IOC", "FREIA-CPCI:")
+epicsEnvSet("EVG", "EVG0")
+epicsEnvSet("DEV1", "$(EVG):")
 
 epicsEnvSet("MainEvtCODE" "14")
 epicsEnvSet("HeartBeatEvtCODE"   "122")
@@ -19,7 +20,7 @@ epicsEnvSet("ESSEvtClockRate"  "88.0525")
 
 mrmEvgSetupPCI("DEVICE", "16:0e.0")
 
-dbLoadRecords("cpci-evg230-ess.db", "SYS=$(IOC), D=$(DEV1), EVG=$(DEV1), FEVT=$(ESSEvtClockRate), FRF=352.21, FDIV=4")
+dbLoadRecords("cpci-evg230-ess.db", "SYS=$(IOC), D=$(DEV1), EVG=$(EVG), FEVT=$(ESSEvtClockRate), FRF=352.21, FDIV=4")
 
 # needed with software timestamp source w/o RT thread scheduling
 var evrMrmTimeNSOverflowThreshold 100000
@@ -30,18 +31,19 @@ iocInit()
 
 dbl > "${IOC}_PVs.list"
 
-dbpf "$(IOC)-$(DEV1):1ppsInp-Sel" "Sys Clk"
+dbpf "$(IOC)$(DEV1)1ppsInp-Sel" "Sys Clk"
 
 # # Master Event Rate 14 Hz
-dbpf $(IOC)-$(DEV1):Mxc0-Prescaler-SP 6289464
-dbpf $(IOC)-$(DEV1):TrigEvt0-EvtCode-SP $(MainEvtCODE)
-dbpf $(IOC)-$(DEV1):TrigEvt0-TrigSrc-Sel "Mxc0"
+dbpf $(IOC)$(DEV1)Mxc0-Prescaler-SP 6289464
+dbpf $(IOC)$(DEV1)TrigEvt0-EvtCode-SP $(MainEvtCODE)
+dbpf $(IOC)$(DEV1)TrigEvt0-TrigSrc-Sel "Mxc0"
 
 # # Heart Beat 1 Hz
-dbpf $(IOC)-$(DEV1):Mxc7-Prescaler-SP 88052496
-dbpf $(IOC)-$(DEV1):TrigEvt7-EvtCode-SP $(HeartBeatEvtCODE)
-dbpf $(IOC)-$(DEV1):TrigEvt7-TrigSrc-Sel "Mxc7"
+dbpf $(IOC)$(DEV1)Mxc7-Prescaler-SP 88052496
+dbpf $(IOC)$(DEV1)TrigEvt7-EvtCode-SP $(HeartBeatEvtCODE)
+dbpf $(IOC)$(DEV1)TrigEvt7-TrigSrc-Sel "Mxc7"
 
 # Is there something similar to sleep(5)????
-dbpf $(IOC)-$(DEV1):SyncTimestamp-Cmd 1
+# <WL> Yes: epicsThreadSleep(5.0)
+dbpf $(IOC)$(DEV1)SyncTimestamp-Cmd 1
 

--- a/cmds/freia01.cmd
+++ b/cmds/freia01.cmd
@@ -12,23 +12,24 @@ epicsEnvSet("LOCATION","Rack 1 at ICS Tuna Lab")
 
 epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 
-epicsEnvSet("IOC", "FREIA")
-epicsEnvSet("DEV1", "EVG0")
+epicsEnvSet("IOC", "FREIA:")
+epicsEnvSet("EVG", "EVG0")
+epicsEnvSet("DEV1", "$(EVG):")
 
 epicsEnvSet("MainEvtCODE" "14")
 epicsEnvSet("HeartBeatEvtCODE"   "122")
 epicsEnvSet("ESSEvtClockRate"  "88.0525")
 
-mrmEvgSetupPCI("$(DEV1)", "10:0e.0")
+mrmEvgSetupPCI("$(EVG)", "10:0e.0")
 
-dbLoadRecords("cpci-evg230-ess.db",  "SYS=$(IOC), D=$(DEV1), EVG=$(DEV1), FEVT=$(ESSEvtClockRate), FRF=352.21, FDIV=4")
+dbLoadRecords("cpci-evg230-ess.db",  "SYS=$(IOC), D=$(DEV1), EVG=$(EVG), FEVT=$(ESSEvtClockRate), FRF=352.21, FDIV=4")
 
 # needed with software timestamp source w/o RT thread scheduling
 var evrMrmTimeNSOverflowThreshold 100000
 
 
 # iocStats
-dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC)-IocStats")
+dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC)IocStats")
 
 
 # # Auto save/restore
@@ -38,7 +39,7 @@ dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC)-IocStats")
 
 # var save_restoreDebug 1
 
-# dbLoadRecords("save_restoreStatus.db", "P=$(IOC)-Autosave")
+# dbLoadRecords("save_restoreStatus.db", "P=$(IOC)Autosave")
 # save_restoreSet_status_prefix("$(IOC):Autosave")
 # set_savefile_path("${AUTOSAVE}")
 # set_requestfile_path("${AUTOSAVE}")
@@ -64,23 +65,23 @@ dbl > "${IOC}_PVs.list"
 
 
 
-dbpf "$(IOC)-$(DEV1):1ppsInp-Sel" "Sys Clk"
+dbpf "$(IOC)$(DEV1)1ppsInp-Sel" "Sys Clk"
 
 # # Master Event Rate 14 Hz
-dbpf $(IOC)-$(DEV1):Mxc0-Prescaler-SP 6289464
-dbpf $(IOC)-$(DEV1):TrigEvt0-EvtCode-SP $(MainEvtCODE)
-dbpf $(IOC)-$(DEV1):TrigEvt0-TrigSrc-Sel "Mxc0"
+dbpf $(IOC)$(DEV1)Mxc0-Prescaler-SP 6289464
+dbpf $(IOC)$(DEV1)TrigEvt0-EvtCode-SP $(MainEvtCODE)
+dbpf $(IOC)$(DEV1)TrigEvt0-TrigSrc-Sel "Mxc0"
 
 # # Heart Beat 1 Hz
-dbpf $(IOC)-$(DEV1):Mxc7-Prescaler-SP 88052496
-dbpf $(IOC)-$(DEV1):TrigEvt7-EvtCode-SP $(HeartBeatEvtCODE)
-dbpf $(IOC)-$(DEV1):TrigEvt7-TrigSrc-Sel "Mxc7"
+dbpf $(IOC)$(DEV1)Mxc7-Prescaler-SP 88052496
+dbpf $(IOC)$(DEV1)TrigEvt7-EvtCode-SP $(HeartBeatEvtCODE)
+dbpf $(IOC)$(DEV1)TrigEvt7-TrigSrc-Sel "Mxc7"
 
 # # EVR configuration
-# dbpf $(IOC)-$(DEV2):DlyGen0-Width-SP 10000
-# dbpf $(IOC)-$(DEV2):DlyGen0-Evt-Trig0-SP $(MainEvtCODE)
-# dbpf $(IOC)-$(DEV2):OutFPUV0-Src-Pulse-SP "Pulser 0"
+# dbpf $(IOC)$(DEV2)DlyGen0-Width-SP 10000
+# dbpf $(IOC)$(DEV2)DlyGen0-Evt-Trig0-SP $(MainEvtCODE)
+# dbpf $(IOC)$(DEV2)OutFPUV0-Src-Pulse-SP "Pulser 0"
 
 # Is there something similar to sleep(5)????
-dbpf $(IOC)-$(DEV1):SyncTimestamp-Cmd 1
+dbpf $(IOC)$(DEV1)SyncTimestamp-Cmd 1
 

--- a/cmds/input2backplane.cmd
+++ b/cmds/input2backplane.cmd
@@ -13,21 +13,22 @@ epicsEnvSet("LOCATION","")
 epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 
 epicsEnvSet("IOC", "INPUT2BACK")
-epicsEnvSet("DEV1", "EVR1")
+epicsEnvSet("EVR", "EVR1")
+epicsEnvSet("DEV1", "$(EVR):")
 
 epicsEnvSet("MainEvtCODE" "14")
 epicsEnvSet("HeartBeatEvtCODE"   "122")
 epicsEnvSet("ESSEvtClockRate"  "88.0525")
 
-mrmEvrSetupPCI("$(DEV1)",  "06:00.0")
-dbLoadRecords("evr-mtca-300u-ess.db","EVR=$(DEV1), SYS=$(IOC), D=$(DEV1), FEVT=$(ESSEvtClockRate)")
+mrmEvrSetupPCI("$(EVR)",  "06:00.0")
+dbLoadRecords("evr-mtca-300u-ess.db","EVR=$(EVR), SYS=$(IOC), D=$(DEV1), FEVT=$(ESSEvtClockRate)")
 
 # needed with software timestamp source w/o RT thread scheduling
 var evrMrmTimeNSOverflowThreshold 100000
 
 
 # iocStats
-# dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC):IocStats")
+# dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC)IocStats")
 
 
 
@@ -37,30 +38,30 @@ iocInit()
 # dbl > "${IOC}_PVs.list"
 
 # Get current time from system clock
-dbpf $(IOC)-$(DEV1):TimeSrc-Sel "Sys. Clock"
+dbpf $(IOC)$(DEV1)TimeSrc-Sel "Sys. Clock"
 
 # Set delay compensation to 70 ns, needed to avoid timesptamp issue
-dbpf $(IOC)-$(DEV1):DC-Tgt-SP 70
+dbpf $(IOC)$(DEV1)DC-Tgt-SP 70
 
 # Set up the prescaler that will trigger the sequencer at 14 Hz
-dbpf $(IOC)-$(DEV1):PS0-Div-SP 6289424 # in standalone mode because real freq from synthsiezer is 88.05194802 MHz, otherwise 6289464
+dbpf $(IOC)$(DEV1)PS0-Div-SP 6289424 # in standalone mode because real freq from synthsiezer is 88.05194802 MHz, otherwise 6289464
 
 # Set up the sequencer
-dbpf $(IOC)-$(DEV1):SoftSeq0-RunMode-Sel "Normal"
-dbpf $(IOC)-$(DEV1):SoftSeq0-TrigSrc-2-Sel "Prescaler 0"
-dbpf $(IOC)-$(DEV1):SoftSeq0-TsResolution-Sel "uSec"
-dbpf $(IOC)-$(DEV1):SoftSeq0-Load-Cmd 1
-dbpf $(IOC)-$(DEV1):SoftSeq0-Enable-Cmd 1
+dbpf $(IOC)$(DEV1)SoftSeq0-RunMode-Sel "Normal"
+dbpf $(IOC)$(DEV1)SoftSeq0-TrigSrc-2-Sel "Prescaler 0"
+dbpf $(IOC)$(DEV1)SoftSeq0-TsResolution-Sel "uSec"
+dbpf $(IOC)$(DEV1)SoftSeq0-Load-Cmd 1
+dbpf $(IOC)$(DEV1)SoftSeq0-Enable-Cmd 1
 
 system("/bin/sh ./configure_sequencer_14Hz.sh $(IOC) $(DEV1)")
 
 # Set up of UnivIO 0 as Input. Generate Code 10 locally on rising edge.
-#dbpf $(IOC)-$(DEV1):OutRB00-Src-SP 61
-dbpf $(IOC)-$(DEV1):In0-Trig-Ext-Sel "Edge"
-dbpf $(IOC)-$(DEV1):In0-Code-Ext-SP 10
+#dbpf $(IOC)$(DEV1)OutRB00-Src-SP 61
+dbpf $(IOC)$(DEV1)In0-Trig-Ext-Sel "Edge"
+dbpf $(IOC)$(DEV1)In0-Code-Ext-SP 10
 
 # Trigger backplane trigger line X at 14 Hz
-# dbpf $(IOC)-$(DEV1):DlyGen0-Evt-Trig0-SP $(MainEvtCODE)
-# dbpf $(IOC)-$(DEV1):DlyGen0-Width-SP 1000 # time in us, as
-# selected with $(IOC)-$(DEV1):SoftSeq0-TsResolution-Sel
-# dbpf $(IOC)-$(DEV1):OutBackX-Src-SP 0 # trigger from delay generator 0
+# dbpf $(IOC)$(DEV1)DlyGen0-Evt-Trig0-SP $(MainEvtCODE)
+# dbpf $(IOC)$(DEV1)DlyGen0-Width-SP 1000 # time in us, as
+# selected with $(IOC)$(DEV1)SoftSeq0-TsResolution-Sel
+# dbpf $(IOC)$(DEV1)OutBackX-Src-SP 0 # trigger from delay generator 0

--- a/cmds/ipc01.cmd
+++ b/cmds/ipc01.cmd
@@ -12,7 +12,7 @@ epicsEnvSet("LOCATION","Table at ICS Tuna Lab")
 
 epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 
-epicsEnvSet("IOC", "Doppler01-PCIE")
+epicsEnvSet("IOC", "Doppler01-PCIE:")
 
 epicsEnvSet("MainEvtCODE" "14")
 epicsEnvSet("HeartBeatEvtCODE"   "122")
@@ -20,8 +20,8 @@ epicsEnvSet("ESSEvtClockRate"  "88.0525")
 
 mrmEvrSetupPCI("EVR1",  "01:00.0")
 mrmEvrSetupPCI("EVR2",  "02:00.0")
-dbLoadRecords("evr-pcie-300dc-ess.db","EVR=EVR1, SYS=$(IOC), D=evr1, FEVT=$(ESSEvtClockRate)")
-dbLoadRecords("evr-pcie-300dc-ess.db","EVR=EVR2, SYS=$(IOC), D=evr2, FEVT=$(ESSEvtClockRate)")
+dbLoadRecords("evr-pcie-300dc-ess.db","EVR=EVR1, SYS=$(IOC), D=evr1:, FEVT=$(ESSEvtClockRate)")
+dbLoadRecords("evr-pcie-300dc-ess.db","EVR=EVR2, SYS=$(IOC), D=evr2:, FEVT=$(ESSEvtClockRate)")
 
 
 # needed with software timestamp source w/o RT thread scheduling
@@ -39,5 +39,5 @@ iocInit()
 dbl > "${IOC}_PVs.list"
 
 # Set delay compensation to 70 ns, needed to avoid timesptamp issue
-dbpf $(IOC)-$(DEV1):DC-Tgt-SP 70
+dbpf $(IOC)$(DEV1)DC-Tgt-SP 70
 

--- a/cmds/mtca-evr-300u_bi-aptm.cmd
+++ b/cmds/mtca-evr-300u_bi-aptm.cmd
@@ -2,6 +2,7 @@
 
 #- iocshLoad "mtca-evr-300u.cmd" "UNIT=1, DEVPATH=06:00.0, IOC=$(IOC)"
 epicsEnvSet("_PORT_EVR", "EVR_$(UNIT)")
+epicsEnvSet("DEV", "$(_PORT_EVR):")
 
 epicsEnvSet("_MainEvtCODE" "14")
 epicsEnvSet("_HeartBeatEvtCODE"   "122")
@@ -10,7 +11,7 @@ epicsEnvSet("_ESSEvtClockRate"  "88.0525")
 
 ### Register the EVR with the IOC and load the database ###
 mrmEvrSetupPCI("$(_PORT_EVR)",  "$(DEVPATH)")
-dbLoadRecords("evr-mtca-300u-ess.db","EVR=$(_PORT_EVR), SYS=$(IOC), D=$(_PORT_EVR), FEVT=$(_ESSEvtClockRate)")
+dbLoadRecords("evr-mtca-300u-ess.db","EVR=$(_PORT_EVR), SYS=$(IOC), D=$(DEV), FEVT=$(_ESSEvtClockRate)")
 
 ### Needed with software timestamp source w/o RT thread scheduling ###
 var evrMrmTimeNSOverflowThreshold 100000

--- a/cmds/mtca-evr-300u_bi-aptm_after_init.cmd
+++ b/cmds/mtca-evr-300u_bi-aptm_after_init.cmd
@@ -1,20 +1,20 @@
 
 #- iocshLoad "mtca-evr-300u.cmd" "UNIT=1, IOC=$(IOC), CMD_TOP=$(CMD_TOP)"
-epicsEnvSet("_PORT_EVR", "EVR_$(UNIT)")
+epicsEnvSet("_PORT_EVR", "EVR_$(UNIT):")
 epicsEnvSet("_TOP",      "$(CMD_TOP)")
 
 ### Get current time from system clock ###
-dbpf $(IOC)-$(_PORT_EVR):TimeSrc-Sel 2
+dbpf $(IOC)$(_PORT_EVR)TimeSrc-Sel 2
 
 ### Set up the prescaler that will trigger the sequencer at 14 Hz ###
-dbpf $(IOC)-$(_PORT_EVR):PS0-Div-SP 6289424 # in standalone mode because real freq from synthsiezer is 88.05194802 MHz, otherwise 6289464
+dbpf $(IOC)$(_PORT_EVR)PS0-Div-SP 6289424 # in standalone mode because real freq from synthsiezer is 88.05194802 MHz, otherwise 6289464
 
 ### Set up the sequencer ###
-dbpf $(IOC)-$(_PORT_EVR):SoftSeq0-RunMode-Sel 0 # normal mode, rearm after finish
-dbpf $(IOC)-$(_PORT_EVR):SoftSeq0-TrigSrc-2-Sel 2 # trigger the sequence from prescaler 0
-dbpf $(IOC)-$(_PORT_EVR):SoftSeq0-TsResolution-Sel 2 # select us as the units of the timestamp array of the seuqncer
-dbpf $(IOC)-$(_PORT_EVR):SoftSeq0-Load-Cmd 1
-dbpf $(IOC)-$(_PORT_EVR):SoftSeq0-Enable-Cmd 1
+dbpf $(IOC)$(_PORT_EVR)SoftSeq0-RunMode-Sel 0 # normal mode, rearm after finish
+dbpf $(IOC)$(_PORT_EVR)SoftSeq0-TrigSrc-2-Sel 2 # trigger the sequence from prescaler 0
+dbpf $(IOC)$(_PORT_EVR)SoftSeq0-TsResolution-Sel 2 # select us as the units of the timestamp array of the seuqncer
+dbpf $(IOC)$(_PORT_EVR)SoftSeq0-Load-Cmd 1
+dbpf $(IOC)$(_PORT_EVR)SoftSeq0-Enable-Cmd 1
 
 
 ### Run the script that configures the events and timestamp of the sequence ###
@@ -24,50 +24,50 @@ system("/bin/sh $(_TOP)/configure_sequencer_14Hz.sh $(IOC) $(_PORT_EVR)")
 
 ################ TRIGGER ALL BACKPLANE LINES ON INPUT ######################
 ### Trigger input on signal edge/level ###
-dbpf $(IOC)-$(_PORT_EVR):In0-Trig-Ext-Sel "Edge"
+dbpf $(IOC)$(_PORT_EVR)In0-Trig-Ext-Sel "Edge"
 ### Active Edge Rising/Falling ###
-dbpf $(IOC)-$(_PORT_EVR):In0-Edge-Sel "Active Rising"
+dbpf $(IOC)$(_PORT_EVR)In0-Edge-Sel "Active Rising"
 ### Active Level High/Low ###
-#dbpf $(IOC)-$(_PORT_EVR):In0-Lvl-Sel "Active High"
+#dbpf $(IOC)$(_PORT_EVR)In0-Lvl-Sel "Active High"
 ### Create event 10 when input is triggered ##
-dbpf $(IOC)-$(_PORT_EVR):In0-Code-Ext-SP 10
+dbpf $(IOC)$(_PORT_EVR)In0-Code-Ext-SP 10
 ### Trigger delay generator 0 on input ###
-dbpf $(IOC)-$(_PORT_EVR):DlyGen0-Evt-Trig0-SP 10
+dbpf $(IOC)$(_PORT_EVR)DlyGen0-Evt-Trig0-SP 10
 ### Set width of the trigger in us ###
-dbpf $(IOC)-$(_PORT_EVR):DlyGen0-Width-SP 1000
+dbpf $(IOC)$(_PORT_EVR)DlyGen0-Width-SP 1000
 ### Set delay of the trigger in us ###
-dbpf $(IOC)-$(_PORT_EVR):DlyGen0-Delay-SP 0
+dbpf $(IOC)$(_PORT_EVR)DlyGen0-Delay-SP 0
 ### Triger backplane lines in delay generator 0 ###
-dbpf $(IOC)-$(_PORT_EVR):OutBack0-Src-SP 0 # trigger from delay generator 0
-dbpf $(IOC)-$(_PORT_EVR):OutBack1-Src-SP 0
-dbpf $(IOC)-$(_PORT_EVR):OutBack2-Src-SP 0
-dbpf $(IOC)-$(_PORT_EVR):OutBack3-Src-SP 0
-dbpf $(IOC)-$(_PORT_EVR):OutBack4-Src-SP 0
-dbpf $(IOC)-$(_PORT_EVR):OutBack5-Src-SP 0
-dbpf $(IOC)-$(_PORT_EVR):OutBack6-Src-SP 0
-dbpf $(IOC)-$(_PORT_EVR):OutBack7-Src-SP 0
+dbpf $(IOC)$(_PORT_EVR)OutBack0-Src-SP 0 # trigger from delay generator 0
+dbpf $(IOC)$(_PORT_EVR)OutBack1-Src-SP 0
+dbpf $(IOC)$(_PORT_EVR)OutBack2-Src-SP 0
+dbpf $(IOC)$(_PORT_EVR)OutBack3-Src-SP 0
+dbpf $(IOC)$(_PORT_EVR)OutBack4-Src-SP 0
+dbpf $(IOC)$(_PORT_EVR)OutBack5-Src-SP 0
+dbpf $(IOC)$(_PORT_EVR)OutBack6-Src-SP 0
+dbpf $(IOC)$(_PORT_EVR)OutBack7-Src-SP 0
 
 ### Send event clock over backplane clock line TCLKB, MCH should be configured to send the clock back to the AMCs over TCLKA ###
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Src-SP 63
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Ena-Sel 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pwr-Sel 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.BF 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.BE 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.BD 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.BC 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.BB 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.BA 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.B9 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.B8 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.B7 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.B6 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.B5 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.B4 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.B3 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.B2 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.B1 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low00_15-SP.B0 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low16_31-SP.BF 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low16_31-SP.BE 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low16_31-SP.BD 1
- dbpf $(IOC)-$(_PORT_EVR):OutTCLKB-Pat-Low16_31-SP.BC 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Src-SP 63
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Ena-Sel 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pwr-Sel 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.BF 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.BE 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.BD 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.BC 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.BB 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.BA 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.B9 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.B8 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.B7 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.B6 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.B5 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.B4 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.B3 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.B2 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.B1 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low00_15-SP.B0 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low16_31-SP.BF 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low16_31-SP.BE 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low16_31-SP.BD 1
+ dbpf $(IOC)$(_PORT_EVR)OutTCLKB-Pat-Low16_31-SP.BC 1

--- a/cmds/populate_sequencer_raster01.sh
+++ b/cmds/populate_sequencer_raster01.sh
@@ -2,10 +2,10 @@
 # All values in us
 
 # Event code 14 (14 Hz), 127 is the end of sequence
-caput -a RM01-PCIE-EVR1:SoftSeq0-EvtCode-SP 2 14 127
+caput -a RM01-PCIE:EVR1:SoftSeq0-EvtCode-SP 2 14 127
 
 # Defining time at which the event codes are sent in us
-caput -a RM01-PCIE-EVR1:SoftSeq0-Timestamp-SP 2 0 1
+caput -a RM01-PCIE:EVR1:SoftSeq0-Timestamp-SP 2 0 1
 
 # Commit the sequence to HW
-caput RM01-PCIE-EVR1:SoftSeq0-Commit-Cmd 1
+caput RM01-PCIE:EVR1:SoftSeq0-Commit-Cmd 1

--- a/cmds/raster01.cmd
+++ b/cmds/raster01.cmd
@@ -11,22 +11,23 @@ epicsEnvSet("LOCATION","Table at ICS Tuna Lab")
 
 epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 
-epicsEnvSet("IOC", "RM01-PCIE")
-epicsEnvSet("DEV1", "EVR1")
+epicsEnvSet("IOC", "RM01-PCIE:")
+epicsEnvSet("EVR", "EVR1")
+epicsEnvSet("DEV1", "$(EVR):")
 
 epicsEnvSet("MainEvtCODE" "14")
 epicsEnvSet("HeartBeatEvtCODE"   "122")
 epicsEnvSet("ESSEvtClockRate"  "88.0525")
 
-mrmEvrSetupPCI("$(DEV1)",  "01:00.0")
-dbLoadRecords("evr-pcie-300dc-ess.db","EVR=$(DEV1), SYS=$(IOC), D=$(DEV1), FEVT=$(ESSEvtClockRate)")
+mrmEvrSetupPCI("$(EVR)",  "01:00.0")
+dbLoadRecords("evr-pcie-300dc-ess.db","EVR=$(EVR), SYS=$(IOC), D=$(DEV1), FEVT=$(ESSEvtClockRate)")
 
 # needed with software timestamp source w/o RT thread scheduling
 var evrMrmTimeNSOverflowThreshold 100000
 
 
 # iocStats
-dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC)-IocStats")
+dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC)IocStats")
 
 
 
@@ -34,32 +35,32 @@ iocInit()
 
 dbl > "${IOC}_PVs.list"
 
-dbpf $(IOC)-$(DEV1):Ena-Sel 1
+dbpf $(IOC)$(DEV1)Ena-Sel 1
 
 # Get current time from system clock
-dbpf $(IOC)-$(DEV1):TimeSrc-Sel "Sys. Clock"
+dbpf $(IOC)$(DEV1)TimeSrc-Sel "Sys. Clock"
 
 # Set delay compensation to 70 ns, needed to avoid timesptamp issue
-dbpf $(IOC)-$(DEV1):DC-Tgt-SP 70
+dbpf $(IOC)$(DEV1)DC-Tgt-SP 70
 
 # Set up the prescaler that will trigger the sequencer at 14 Hz
-dbpf $(IOC)-$(DEV1):PS0-Div-SP 6289464
+dbpf $(IOC)$(DEV1)PS0-Div-SP 6289464
 
 # Set up the sequencer
-dbpf $(IOC)-$(DEV1):SoftSeq0-RunMode-Sel "Normal"
-dbpf $(IOC)-$(DEV1):SoftSeq0-TrigSrc-2-Sel "Prescaler 0"
-dbpf $(IOC)-$(DEV1):SoftSeq0-TsResolution-Sel "uSec"
-dbpf $(IOC)-$(DEV1):SoftSeq0-Load-Cmd 1
-dbpf $(IOC)-$(DEV1):SoftSeq0-Enable-Cmd 1
+dbpf $(IOC)$(DEV1)SoftSeq0-RunMode-Sel "Normal"
+dbpf $(IOC)$(DEV1)SoftSeq0-TrigSrc-2-Sel "Prescaler 0"
+dbpf $(IOC)$(DEV1)SoftSeq0-TsResolution-Sel "uSec"
+dbpf $(IOC)$(DEV1)SoftSeq0-Load-Cmd 1
+dbpf $(IOC)$(DEV1)SoftSeq0-Enable-Cmd 1
 # Remember to run the script that populates the sequencer!
 
 # Set up the output
-dbpf $(IOC)-$(DEV1):DlyGen0-Evt-Trig0-SP $(MainEvtCODE)
-dbpf $(IOC)-$(DEV1):DlyGen0-Width-SP 1000 # Time in us
-dbpf $(IOC)-$(DEV1):OutRB08-Src-SP 0 # Delay generator 0
+dbpf $(IOC)$(DEV1)DlyGen0-Evt-Trig0-SP $(MainEvtCODE)
+dbpf $(IOC)$(DEV1)DlyGen0-Width-SP 1000 # Time in us
+dbpf $(IOC)$(DEV1)OutRB08-Src-SP 0 # Delay generator 0
 
-dbpf $(IOC)-$(DEV1):OutRB09-Src-SP 41 # Prescaler 1
-dbpf $(IOC)-$(DEV1):PS1-Div-SP 10000000
+dbpf $(IOC)$(DEV1)OutRB09-Src-SP 41 # Prescaler 1
+dbpf $(IOC)$(DEV1)PS1-Div-SP 10000000
 
 pcidiagset 1 0 0 
 #pciread 32 0x50 100

--- a/cmds/ts01.cmd
+++ b/cmds/ts01.cmd
@@ -11,9 +11,11 @@ epicsEnvSet("LOCATION","Rack 1 at ICS Tuna Lab")
 
 epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 
-epicsEnvSet("IOC", "TS01-CPCI")
-epicsEnvSet("DEV1", "EVG0")
-epicsEnvSet("DEV2", "EVR0")
+epicsEnvSet("IOC", "TS01-CPCI:")
+epicsEnvSet("EVG", "EVG0")
+epicsEnvSet("EVR", "EVR0")
+epicsEnvSet("DEV1", "$(EVG):")
+epicsEnvSet("DEV2", "$(EVR):")
 
 epicsEnvSet("MainEvtCODE" "14")
 epicsEnvSet("HeartBeatEvtCODE"   "122")
@@ -22,10 +24,10 @@ epicsEnvSet("ESSEvtClockRate"  "88.0525")
 #epicsEnvSet("BeaconEvt"  "126")
 #epicsEnvSet("1KHzFreq"  "88000")
 
-mrmEvgSetupPCI($(DEV1), "16:0e.0")
-mrmEvrSetupPCI($(DEV2),  "16:09.0")
-dbLoadRecords("cpci-evg230-ess.db",  "SYS=$(IOC), D=$(DEV1), EVG=$(DEV1), FEVT=$(ESSEvtClockRate), FRF=$(ESSEvtClockRate), FDIV=1")
-dbLoadRecords("evr-cpci-230.db","SYS=$(IOC), D=$(DEV2), EVR=$(DEV2),  FEVT=$(ESSEvtClockRate)")
+mrmEvgSetupPCI($(EVG), "16:0e.0")
+mrmEvrSetupPCI($(EVR),  "16:09.0")
+dbLoadRecords("cpci-evg230-ess.db",  "SYS=$(IOC), D=$(DEV1), EVG=$(EVG), FEVT=$(ESSEvtClockRate), FRF=$(ESSEvtClockRate), FDIV=1")
+dbLoadRecords("evr-cpci-230.db","SYS=$(IOC), D=$(DEV2), EVR=$(EVR),  FEVT=$(ESSEvtClockRate)")
 
 # needed with software timestamp source w/o RT thread scheduling
 var evrMrmTimeNSOverflowThreshold 100000
@@ -33,7 +35,7 @@ var evrMrmTimeNSOverflowThreshold 100000
 # mrmEvrLoopback($(DEV2),1,0)
 
 # iocStats
-dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC)-IocStats")
+dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC)IocStats")
 
 
 # Auto save/restore
@@ -68,53 +70,53 @@ dbl > "${IOC}_PVs.list"
 #create_monitor_set("mrf_waveforms.req", 30 , "")
 
 
-dbpf "$(IOC)-$(DEV1):1ppsInp-Sel" "Sys Clk"
+dbpf "$(IOC)$(DEV1)1ppsInp-Sel" "Sys Clk"
 
 ############### Configure RF input ##########
-dbpf $(IOC)-$(DEV1):EvtClk-Source-Sel "RF"
-dbpf $(IOC)-$(DEV1):EvtClk-RFFreq-SP 88.0525
-dbpf $(IOC)-$(DEV1):EvtClk-RFDiv-SP 1
+dbpf $(IOC)$(DEV1)EvtClk-Source-Sel "RF"
+dbpf $(IOC)$(DEV1)EvtClk-RFFreq-SP 88.0525
+dbpf $(IOC)$(DEV1)EvtClk-RFDiv-SP 1
 ############### Configure RF input ##########
 
 ############## Configure front panel for evr 125 1 Hz ##############
-dbpf $(IOC)-$(DEV1):TrigEvt1-EvtCode-SP 125
-dbpf $(IOC)-$(DEV1):TrigEvt1-TrigSrc-Sel "Univ0"
-dbpf $(IOC)-$(DEV1):1ppsInp-Sel "Univ0"
-dbpf $(IOC)-$(DEV1):1ppsInp-MbbiDir_.TPRO 1
+dbpf $(IOC)$(DEV1)TrigEvt1-EvtCode-SP 125
+dbpf $(IOC)$(DEV1)TrigEvt1-TrigSrc-Sel "Univ0"
+dbpf $(IOC)$(DEV1)1ppsInp-Sel "Univ0"
+dbpf $(IOC)$(DEV1)1ppsInp-MbbiDir_.TPRO 1
 ############## Configure front panel for evr 125 1 Hz ##############
 
 ############## Master Event Rate 14 Hz ##############
-dbpf $(IOC)-$(DEV1):Mxc0-Prescaler-SP 6289464
-#dbpf $(IOC)-$(DEV1):TrigEvt0-EvtCode-SP $(MainEvtCODE)
-#dbpf $(IOC)-$(DEV1):TrigEvt0-TrigSrc-Sel "Mxc0"
+dbpf $(IOC)$(DEV1)Mxc0-Prescaler-SP 6289464
+#dbpf $(IOC)$(DEV1)TrigEvt0-EvtCode-SP $(MainEvtCODE)
+#dbpf $(IOC)$(DEV1)TrigEvt0-TrigSrc-Sel "Mxc0"
 # Setup of sequencer
-dbpf $(IOC)-$(DEV1):SoftSeq0-RunMode-Sel "Normal"
-dbpf $(IOC)-$(DEV1):SoftSeq0-TrigSrc-Sel "Mxc0"
-dbpf $(IOC)-$(DEV1):SoftSeq0-TsResolution-Sel "uSec"
-dbpf $(IOC)-$(DEV1):SoftSeq0-Load-Cmd 1
-dbpf $(IOC)-$(DEV1):SoftSeq0-Enable-Cmd 1
+dbpf $(IOC)$(DEV1)SoftSeq0-RunMode-Sel "Normal"
+dbpf $(IOC)$(DEV1)SoftSeq0-TrigSrc-Sel "Mxc0"
+dbpf $(IOC)$(DEV1)SoftSeq0-TsResolution-Sel "uSec"
+dbpf $(IOC)$(DEV1)SoftSeq0-Load-Cmd 1
+dbpf $(IOC)$(DEV1)SoftSeq0-Enable-Cmd 1
 # Load the sequence
 system("/bin/sh ./configure_sequencer_14Hz.sh $(IOC) $(DEV1)")
 ############## Master Event Rate 14 Hz ##############
 
 # # Heart Beat 1 Hz
-dbpf $(IOC)-$(DEV1):Mxc7-Prescaler-SP 88052500
-dbpf $(IOC)-$(DEV1):TrigEvt7-EvtCode-SP $(HeartBeatEvtCODE)
-dbpf $(IOC)-$(DEV1):TrigEvt7-TrigSrc-Sel "Mxc7"
+dbpf $(IOC)$(DEV1)Mxc7-Prescaler-SP 88052500
+dbpf $(IOC)$(DEV1)TrigEvt7-EvtCode-SP $(HeartBeatEvtCODE)
+dbpf $(IOC)$(DEV1)TrigEvt7-TrigSrc-Sel "Mxc7"
 
 # # Beacon event 0x7e for EVM as fanout
-#dbpf $(IOC)-$(DEV1):Mxc6-Prescaler-SP $(1KHzFreq)
-#dbpf $(IOC)-$(DEV1):TrigEvt6-EvtCode-SP $(BeaconEvt)
-#dbpf $(IOC)-$(DEV1):TrigEvt6-TrigSrc-Sel "Mxc6"
+#dbpf $(IOC)$(DEV1)Mxc6-Prescaler-SP $(1KHzFreq)
+#dbpf $(IOC)$(DEV1)TrigEvt6-EvtCode-SP $(BeaconEvt)
+#dbpf $(IOC)$(DEV1)TrigEvt6-TrigSrc-Sel "Mxc6"
 
 # # EVR configuration
 # # Set delay compensation to 70 ns, needed to avoid timesptamp issue
-# dbpf $(IOC)-$(DEV1):DC-Tgt-SP 70
-# dbpf $(IOC)-$(DEV2):DlyGen0-Width-SP 10000
-# dbpf $(IOC)-$(DEV2):DlyGen0-Evt-Trig0-SP $(MainEvtCODE)
-# dbpf $(IOC)-$(DEV2):OutFPUV0-Src-Pulse-SP "Pulser 0"
+# dbpf $(IOC)$(DEV1)DC-Tgt-SP 70
+# dbpf $(IOC)$(DEV2)DlyGen0-Width-SP 10000
+# dbpf $(IOC)$(DEV2)DlyGen0-Evt-Trig0-SP $(MainEvtCODE)
+# dbpf $(IOC)$(DEV2)OutFPUV0-Src-Pulse-SP "Pulser 0"
 
 epicsThreadSleep 5
-dbpf $(IOC)-$(DEV1):SyncTimestamp-Cmd 1
+dbpf $(IOC)$(DEV1)SyncTimestamp-Cmd 1
 
 

--- a/cmds/wavengen_trigg.cmd
+++ b/cmds/wavengen_trigg.cmd
@@ -12,15 +12,16 @@ epicsEnvSet("LOCATION","")
 
 epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 
-epicsEnvSet("IOC", "WAVEGENTRIG")
-epicsEnvSet("DEV1", "EVR1")
+epicsEnvSet("IOC", "WAVEGENTRIG:")
+epicsEnvSet("EVR", "EVR1")
+epicsEnvSet("DEV1", "$(EVR):")
 
 epicsEnvSet("MainEvtCODE" "14")
 epicsEnvSet("HeartBeatEvtCODE"   "122")
 epicsEnvSet("ESSEvtClockRate"  "88.0525")
 
-mrmEvrSetupPCI("$(DEV1)",  "01:00.0")
-dbLoadRecords("evr-pcie-300dc-ess.db","EVR=$(DEV1), SYS=$(IOC), D=$(DEV1), FEVT=$(ESSEvtClockRate)")
+mrmEvrSetupPCI("$(EVR)",  "01:00.0")
+dbLoadRecords("evr-pcie-300dc-ess.db","EVR=$(EVR), SYS=$(IOC), D=$(DEV1), FEVT=$(ESSEvtClockRate)")
 
 
 # needed with software timestamp source w/o RT thread scheduling
@@ -28,7 +29,7 @@ var evrMrmTimeNSOverflowThreshold 100000
 
 
 # iocStats
-#dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC):IocStats")
+#dbLoadRecords("iocAdminSoft.db", "IOC=$(IOC)IocStats")
 
 
 
@@ -38,9 +39,9 @@ iocInit()
 #dbl > "${IOC}_PVs.list"
 
 # Set delay compensation to 70 ns, needed to avoid timesptamp issue
-dbpf $(IOC)-$(DEV1):DC-Tgt-SP 70
+dbpf $(IOC)$(DEV1)DC-Tgt-SP 70
 
-dbpf $(IOC)-$(DEV1):DlyGen0-Evt-Trig0-SP 122
-dbpf $(IOC)-$(DEV1):DlyGen0-Width-SP 1000
-dbpf $(IOC)-$(DEV1):OutFPUV02-Src-SP 0
+dbpf $(IOC)$(DEV1)DlyGen0-Evt-Trig0-SP 122
+dbpf $(IOC)$(DEV1)DlyGen0-Width-SP 1000
+dbpf $(IOC)$(DEV1)OutFPUV02-Src-SP 0
 

--- a/template/cpci-evg230-ess.substitutions
+++ b/template/cpci-evg230-ess.substitutions
@@ -1,87 +1,87 @@
 file evgAcTrig.db {
 pattern { P, OBJ }
-{ "$(SYS)-$(D):AcTrig-", "$(EVG):AcTrig" }
+{ "$(SYS)$(D)AcTrig-", "$(EVG)$(SEP=:)AcTrig" }
 }
 
 file evgDbus.db {
 pattern { P, PSRC, OBJ, EVG, dbusBit }
-{ "$(SYS)-$(D):Dbus0-", "$(SYS)-$(D):Dbus0-Src-", "$(EVG):Dbus0", $(EVG), 0 }
-{ "$(SYS)-$(D):Dbus1-", "$(SYS)-$(D):Dbus1-Src-", "$(EVG):Dbus1", $(EVG), 1 }
-{ "$(SYS)-$(D):Dbus2-", "$(SYS)-$(D):Dbus2-Src-", "$(EVG):Dbus2", $(EVG), 2 }
-{ "$(SYS)-$(D):Dbus3-", "$(SYS)-$(D):Dbus3-Src-", "$(EVG):Dbus3", $(EVG), 3 }
-{ "$(SYS)-$(D):Dbus4-", "$(SYS)-$(D):Dbus4-Src-", "$(EVG):Dbus4", $(EVG), 4 }
-{ "$(SYS)-$(D):Dbus5-", "$(SYS)-$(D):Dbus5-Src-", "$(EVG):Dbus5", $(EVG), 5 }
-{ "$(SYS)-$(D):Dbus6-", "$(SYS)-$(D):Dbus6-Src-", "$(EVG):Dbus6", $(EVG), 6 }
-{ "$(SYS)-$(D):Dbus7-", "$(SYS)-$(D):Dbus7-Src-", "$(EVG):Dbus7", $(EVG), 7 }
+{ "$(SYS)$(D)Dbus0-", "$(SYS)$(D)Dbus0-Src-", "$(EVG)$(SEP=:)Dbus0", $(EVG), 0 }
+{ "$(SYS)$(D)Dbus1-", "$(SYS)$(D)Dbus1-Src-", "$(EVG)$(SEP=:)Dbus1", $(EVG), 1 }
+{ "$(SYS)$(D)Dbus2-", "$(SYS)$(D)Dbus2-Src-", "$(EVG)$(SEP=:)Dbus2", $(EVG), 2 }
+{ "$(SYS)$(D)Dbus3-", "$(SYS)$(D)Dbus3-Src-", "$(EVG)$(SEP=:)Dbus3", $(EVG), 3 }
+{ "$(SYS)$(D)Dbus4-", "$(SYS)$(D)Dbus4-Src-", "$(EVG)$(SEP=:)Dbus4", $(EVG), 4 }
+{ "$(SYS)$(D)Dbus5-", "$(SYS)$(D)Dbus5-Src-", "$(EVG)$(SEP=:)Dbus5", $(EVG), 5 }
+{ "$(SYS)$(D)Dbus6-", "$(SYS)$(D)Dbus6-Src-", "$(EVG)$(SEP=:)Dbus6", $(EVG), 6 }
+{ "$(SYS)$(D)Dbus7-", "$(SYS)$(D)Dbus7-Src-", "$(EVG)$(SEP=:)Dbus7", $(EVG), 7 }
 }
 
 
 file evgEvtClk.db {
-{P="$(SYS)-$(D):EvtClk-", OBJ="$(EVG):EvtClk", FRF="\$(FRF=499.68)", FDIV="\$(FDIV=4)", FEVT="\$(FEVT=124.916)"}
+{P="$(SYS)$(D)EvtClk-", OBJ="$(EVG)$(SEP=:)EvtClk", FRF="\$(FRF=499.68)", FDIV="\$(FDIV=4)", FEVT="\$(FEVT=124.916)"}
 }
 
 
 
 file evgInput.db {
 pattern { P, OBJ, SYS, D, SYSD, Num }
-{ "$(SYS)-$(D):InpUniv0-",  "$(EVG):UnivInp0",  $(SYS), $(D), "$(SYS)-$(D):", 2 }
-{ "$(SYS)-$(D):InpUniv1-",  "$(EVG):UnivInp1",  $(SYS), $(D), "$(SYS)-$(D):", 3 }
-{ "$(SYS)-$(D):InpUniv2-",  "$(EVG):UnivInp2",  $(SYS), $(D), "$(SYS)-$(D):", 4 }
-{ "$(SYS)-$(D):InpUniv3-",  "$(EVG):UnivInp3",  $(SYS), $(D), "$(SYS)-$(D):", 5 }
+{ "$(SYS)$(D)InpUniv0-",  "$(EVG)$(SEP=:)UnivInp0",  $(SYS), $(D), "$(SYS)$(D)", 2 }
+{ "$(SYS)$(D)InpUniv1-",  "$(EVG)$(SEP=:)UnivInp1",  $(SYS), $(D), "$(SYS)$(D)", 3 }
+{ "$(SYS)$(D)InpUniv2-",  "$(EVG)$(SEP=:)UnivInp2",  $(SYS), $(D), "$(SYS)$(D)", 4 }
+{ "$(SYS)$(D)InpUniv3-",  "$(EVG)$(SEP=:)UnivInp3",  $(SYS), $(D), "$(SYS)$(D)", 5 }
 }
 
 file evgMrm.db {
-{ P="$(SYS)-$(D):", SOFTEVT="$(SYS)-$(D):SoftEvt-", OBJ="$(EVG)", EVG="$(EVG)" }
+{ P="$(SYS)$(D)", SOFTEVT="$(SYS)$(D)SoftEvt-", OBJ="$(EVG)", EVG="$(EVG)" }
 }
 
 
 file evgMxc.db {
 pattern { P, OBJ, SYS, D, SYSD, SYSDEVTCLK }
-{ "$(SYS)-$(D):Mxc0-", "$(EVG):Mxc0", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
-{ "$(SYS)-$(D):Mxc1-", "$(EVG):Mxc1", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
-{ "$(SYS)-$(D):Mxc2-", "$(EVG):Mxc2", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
-{ "$(SYS)-$(D):Mxc3-", "$(EVG):Mxc3", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
-{ "$(SYS)-$(D):Mxc4-", "$(EVG):Mxc4", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
-{ "$(SYS)-$(D):Mxc5-", "$(EVG):Mxc5", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
-{ "$(SYS)-$(D):Mxc6-", "$(EVG):Mxc6", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
-{ "$(SYS)-$(D):Mxc7-", "$(EVG):Mxc7", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
+{ "$(SYS)$(D)Mxc0-", "$(EVG)$(SEP=:)Mxc0", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
+{ "$(SYS)$(D)Mxc1-", "$(EVG)$(SEP=:)Mxc1", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
+{ "$(SYS)$(D)Mxc2-", "$(EVG)$(SEP=:)Mxc2", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
+{ "$(SYS)$(D)Mxc3-", "$(EVG)$(SEP=:)Mxc3", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
+{ "$(SYS)$(D)Mxc4-", "$(EVG)$(SEP=:)Mxc4", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
+{ "$(SYS)$(D)Mxc5-", "$(EVG)$(SEP=:)Mxc5", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
+{ "$(SYS)$(D)Mxc6-", "$(EVG)$(SEP=:)Mxc6", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
+{ "$(SYS)$(D)Mxc7-", "$(EVG)$(SEP=:)Mxc7", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
 }
 
 file mrmSoftSeq.template {
 pattern { P, PINITSEQ, PTRIGSRC, EVG, seqNum, NELM }
-{ "$(SYS)-$(D):SoftSeq0-", "$(SYS)-$(D):SoftSeq0-InitSeq-", "$(SYS)-$(D):SoftSeq0-TrigSrc-", "$(EVG)", 0, 2047 }
-{ "$(SYS)-$(D):SoftSeq1-", "$(SYS)-$(D):SoftSeq1-InitSeq-", "$(SYS)-$(D):SoftSeq1-TrigSrc-", "$(EVG)", 1, 2047 }
-{ "$(SYS)-$(D):SoftSeq2-", "$(SYS)-$(D):SoftSeq2-InitSeq-", "$(SYS)-$(D):SoftSeq2-TrigSrc-", "$(EVG)", 2, 2047 }
+{ "$(SYS)$(D)SoftSeq0-", "$(SYS)$(D)SoftSeq0-InitSeq-", "$(SYS)$(D)SoftSeq0-TrigSrc-", "$(EVG)", 0, 2047 }
+{ "$(SYS)$(D)SoftSeq1-", "$(SYS)$(D)SoftSeq1-InitSeq-", "$(SYS)$(D)SoftSeq1-TrigSrc-", "$(EVG)", 1, 2047 }
+{ "$(SYS)$(D)SoftSeq2-", "$(SYS)$(D)SoftSeq2-InitSeq-", "$(SYS)$(D)SoftSeq2-TrigSrc-", "$(EVG)", 2, 2047 }
 }
 
 file evgSoftSeq.template {
 pattern { P, PTRIGSRC, PEVTCLKFREQ, SYSDEVTCLK, EVG, seqNum, NELM }
-{ "$(SYS)-$(D):SoftSeq0-", "$(SYS)-$(D):SoftSeq0-TrigSrc-", "$(SYS)-$(D):SoftSeq0-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", $(EVG), 0, 2047 }
-{ "$(SYS)-$(D):SoftSeq1-", "$(SYS)-$(D):SoftSeq1-TrigSrc-", "$(SYS)-$(D):SoftSeq1-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", $(EVG), 1, 2047 }
-{ "$(SYS)-$(D):SoftSeq2-", "$(SYS)-$(D):SoftSeq2-TrigSrc-", "$(SYS)-$(D):SoftSeq2-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", $(EVG), 2, 2047 }
+{ "$(SYS)$(D)SoftSeq0-", "$(SYS)$(D)SoftSeq0-TrigSrc-", "$(SYS)$(D)SoftSeq0-EvtClkFreq-", "$(SYS)$(D)EvtClk-", $(EVG), 0, 2047 }
+{ "$(SYS)$(D)SoftSeq1-", "$(SYS)$(D)SoftSeq1-TrigSrc-", "$(SYS)$(D)SoftSeq1-EvtClkFreq-", "$(SYS)$(D)EvtClk-", $(EVG), 1, 2047 }
+{ "$(SYS)$(D)SoftSeq2-", "$(SYS)$(D)SoftSeq2-TrigSrc-", "$(SYS)$(D)SoftSeq2-EvtClkFreq-", "$(SYS)$(D)EvtClk-", $(EVG), 2, 2047 }
 }
 
 file evgTrigEvt.db {
 pattern { P, PTRIGSRC, POMSL, OBJ, EVG, trigEvtNum }
-{ "$(SYS)-$(D):TrigEvt0-", "$(SYS)-$(D):TrigEvt0-TrigSrc-", "$(SYS)-$(D):TrigEvt0-Omsl-", "$(EVG):TrigEvt0", $(EVG), 0 }
-{ "$(SYS)-$(D):TrigEvt1-", "$(SYS)-$(D):TrigEvt1-TrigSrc-", "$(SYS)-$(D):TrigEvt1-Omsl-", "$(EVG):TrigEvt1", $(EVG), 1 }
-{ "$(SYS)-$(D):TrigEvt2-", "$(SYS)-$(D):TrigEvt2-TrigSrc-", "$(SYS)-$(D):TrigEvt2-Omsl-", "$(EVG):TrigEvt2", $(EVG), 2 }
-{ "$(SYS)-$(D):TrigEvt3-", "$(SYS)-$(D):TrigEvt3-TrigSrc-", "$(SYS)-$(D):TrigEvt3-Omsl-", "$(EVG):TrigEvt3", $(EVG), 3 }
-{ "$(SYS)-$(D):TrigEvt4-", "$(SYS)-$(D):TrigEvt4-TrigSrc-", "$(SYS)-$(D):TrigEvt4-Omsl-", "$(EVG):TrigEvt4", $(EVG), 4 }
-{ "$(SYS)-$(D):TrigEvt5-", "$(SYS)-$(D):TrigEvt5-TrigSrc-", "$(SYS)-$(D):TrigEvt5-Omsl-", "$(EVG):TrigEvt5", $(EVG), 5 }
-{ "$(SYS)-$(D):TrigEvt6-", "$(SYS)-$(D):TrigEvt6-TrigSrc-", "$(SYS)-$(D):TrigEvt6-Omsl-", "$(EVG):TrigEvt6", $(EVG), 6 }
-{ "$(SYS)-$(D):TrigEvt7-", "$(SYS)-$(D):TrigEvt7-TrigSrc-", "$(SYS)-$(D):TrigEvt7-Omsl-", "$(EVG):TrigEvt7", $(EVG), 7 }
+{ "$(SYS)$(D)TrigEvt0-", "$(SYS)$(D)TrigEvt0-TrigSrc-", "$(SYS)$(D)TrigEvt0-Omsl-", "$(EVG)$(SEP=:)TrigEvt0", $(EVG), 0 }
+{ "$(SYS)$(D)TrigEvt1-", "$(SYS)$(D)TrigEvt1-TrigSrc-", "$(SYS)$(D)TrigEvt1-Omsl-", "$(EVG)$(SEP=:)TrigEvt1", $(EVG), 1 }
+{ "$(SYS)$(D)TrigEvt2-", "$(SYS)$(D)TrigEvt2-TrigSrc-", "$(SYS)$(D)TrigEvt2-Omsl-", "$(EVG)$(SEP=:)TrigEvt2", $(EVG), 2 }
+{ "$(SYS)$(D)TrigEvt3-", "$(SYS)$(D)TrigEvt3-TrigSrc-", "$(SYS)$(D)TrigEvt3-Omsl-", "$(EVG)$(SEP=:)TrigEvt3", $(EVG), 3 }
+{ "$(SYS)$(D)TrigEvt4-", "$(SYS)$(D)TrigEvt4-TrigSrc-", "$(SYS)$(D)TrigEvt4-Omsl-", "$(EVG)$(SEP=:)TrigEvt4", $(EVG), 4 }
+{ "$(SYS)$(D)TrigEvt5-", "$(SYS)$(D)TrigEvt5-TrigSrc-", "$(SYS)$(D)TrigEvt5-Omsl-", "$(EVG)$(SEP=:)TrigEvt5", $(EVG), 5 }
+{ "$(SYS)$(D)TrigEvt6-", "$(SYS)$(D)TrigEvt6-TrigSrc-", "$(SYS)$(D)TrigEvt6-Omsl-", "$(EVG)$(SEP=:)TrigEvt6", $(EVG), 6 }
+{ "$(SYS)$(D)TrigEvt7-", "$(SYS)$(D)TrigEvt7-TrigSrc-", "$(SYS)$(D)TrigEvt7-Omsl-", "$(EVG)$(SEP=:)TrigEvt7", $(EVG), 7 }
 }
 
 file databuftx.db
 {pattern
 { P, OBJ, PROTO }
-{ "$(SYS)-$(D):dbus-send-", "$(EVG):BUFTX", 1 }
+{ "$(SYS)$(D)dbus-send-", "$(EVG)$(SEP=:)BUFTX", 1 }
 }
 
 file "databuftxCtrl.db"
 {pattern
 { P, OBJ }
-{ "$(SYS)-$(D):Link-", "$(EVG):BUFTX" }
+{ "$(SYS)$(D)Link-", "$(EVG)$(SEP=:)BUFTX" }
 }
 

--- a/template/evg-cpci-230-ess.substitutions
+++ b/template/evg-cpci-230-ess.substitutions
@@ -1,87 +1,87 @@
 file evgAcTrig.db {
 pattern { P, OBJ }
-{ "$(SYS)-$(D):AcTrig-", "$(EVG):AcTrig" }
+{ "$(SYS)$(D)AcTrig-", "$(EVG)$(SEP=:)AcTrig" }
 }
 
 file evgDbus.db {
 pattern { P, PSRC, OBJ, EVG, dbusBit }
-{ "$(SYS)-$(D):Dbus0-", "$(SYS)-$(D):Dbus0-Src-", "$(EVG):Dbus0", $(EVG), 0 }
-{ "$(SYS)-$(D):Dbus1-", "$(SYS)-$(D):Dbus1-Src-", "$(EVG):Dbus1", $(EVG), 1 }
-{ "$(SYS)-$(D):Dbus2-", "$(SYS)-$(D):Dbus2-Src-", "$(EVG):Dbus2", $(EVG), 2 }
-{ "$(SYS)-$(D):Dbus3-", "$(SYS)-$(D):Dbus3-Src-", "$(EVG):Dbus3", $(EVG), 3 }
-{ "$(SYS)-$(D):Dbus4-", "$(SYS)-$(D):Dbus4-Src-", "$(EVG):Dbus4", $(EVG), 4 }
-{ "$(SYS)-$(D):Dbus5-", "$(SYS)-$(D):Dbus5-Src-", "$(EVG):Dbus5", $(EVG), 5 }
-{ "$(SYS)-$(D):Dbus6-", "$(SYS)-$(D):Dbus6-Src-", "$(EVG):Dbus6", $(EVG), 6 }
-{ "$(SYS)-$(D):Dbus7-", "$(SYS)-$(D):Dbus7-Src-", "$(EVG):Dbus7", $(EVG), 7 }
+{ "$(SYS)$(D)Dbus0-", "$(SYS)$(D)Dbus0-Src-", "$(EVG)$(SEP=:)Dbus0", $(EVG), 0 }
+{ "$(SYS)$(D)Dbus1-", "$(SYS)$(D)Dbus1-Src-", "$(EVG)$(SEP=:)Dbus1", $(EVG), 1 }
+{ "$(SYS)$(D)Dbus2-", "$(SYS)$(D)Dbus2-Src-", "$(EVG)$(SEP=:)Dbus2", $(EVG), 2 }
+{ "$(SYS)$(D)Dbus3-", "$(SYS)$(D)Dbus3-Src-", "$(EVG)$(SEP=:)Dbus3", $(EVG), 3 }
+{ "$(SYS)$(D)Dbus4-", "$(SYS)$(D)Dbus4-Src-", "$(EVG)$(SEP=:)Dbus4", $(EVG), 4 }
+{ "$(SYS)$(D)Dbus5-", "$(SYS)$(D)Dbus5-Src-", "$(EVG)$(SEP=:)Dbus5", $(EVG), 5 }
+{ "$(SYS)$(D)Dbus6-", "$(SYS)$(D)Dbus6-Src-", "$(EVG)$(SEP=:)Dbus6", $(EVG), 6 }
+{ "$(SYS)$(D)Dbus7-", "$(SYS)$(D)Dbus7-Src-", "$(EVG)$(SEP=:)Dbus7", $(EVG), 7 }
 }
 
 
 file evgEvtClk.db {
-{P="$(SYS)-$(D):EvtClk-", OBJ="$(EVG):EvtClk", FRF="\$(FRF=499.68)", FDIV="\$(FDIV=4)", FEVT="\$(FEVT=124.916)"}
+{P="$(SYS)$(D)EvtClk-", OBJ="$(EVG)$(SEP=:)EvtClk", FRF="\$(FRF=499.68)", FDIV="\$(FDIV=4)", FEVT="\$(FEVT=124.916)"}
 }
 
 
 
 file evgInput.db {
 pattern { P, OBJ, SYS, D, SYSD, Num }
-{ "$(SYS)-$(D):InpUniv0-",  "$(EVG):UnivInp0",  $(SYS), $(D), "$(SYS)-$(D):", 2 }
-{ "$(SYS)-$(D):InpUniv1-",  "$(EVG):UnivInp1",  $(SYS), $(D), "$(SYS)-$(D):", 3 }
-{ "$(SYS)-$(D):InpUniv2-",  "$(EVG):UnivInp2",  $(SYS), $(D), "$(SYS)-$(D):", 4 }
-{ "$(SYS)-$(D):InpUniv3-",  "$(EVG):UnivInp3",  $(SYS), $(D), "$(SYS)-$(D):", 5 }
+{ "$(SYS)$(D)InpUniv0-",  "$(EVG)$(SEP=:)UnivInp0",  $(SYS), $(D), "$(SYS)$(D)", 2 }
+{ "$(SYS)$(D)InpUniv1-",  "$(EVG)$(SEP=:)UnivInp1",  $(SYS), $(D), "$(SYS)$(D)", 3 }
+{ "$(SYS)$(D)InpUniv2-",  "$(EVG)$(SEP=:)UnivInp2",  $(SYS), $(D), "$(SYS)$(D)", 4 }
+{ "$(SYS)$(D)InpUniv3-",  "$(EVG)$(SEP=:)UnivInp3",  $(SYS), $(D), "$(SYS)$(D)", 5 }
 }
 
 file evgMrm.db {
-{ P="$(SYS)-$(D):", SOFTEVT="$(SYS)-$(D):SoftEvt-", OBJ="$(EVG)", EVG="$(EVG)" }
+{ P="$(SYS)$(D)", SOFTEVT="$(SYS)$(D)SoftEvt-", OBJ="$(EVG)", EVG="$(EVG)" }
 }
 
 
 file evgMxc.db {
 pattern { P, OBJ, SYS, D, SYSD, SYSDEVTCLK }
-{ "$(SYS)-$(D):Mxc0-", "$(EVG):Mxc0", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
-{ "$(SYS)-$(D):Mxc1-", "$(EVG):Mxc1", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
-{ "$(SYS)-$(D):Mxc2-", "$(EVG):Mxc2", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
-{ "$(SYS)-$(D):Mxc3-", "$(EVG):Mxc3", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
-{ "$(SYS)-$(D):Mxc4-", "$(EVG):Mxc4", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
-{ "$(SYS)-$(D):Mxc5-", "$(EVG):Mxc5", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
-{ "$(SYS)-$(D):Mxc6-", "$(EVG):Mxc6", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
-{ "$(SYS)-$(D):Mxc7-", "$(EVG):Mxc7", $(SYS), $(D), "$(SYS)-$(D):", "$(SYS)-$(D):EvtClk-" }
+{ "$(SYS)$(D)Mxc0-", "$(EVG)$(SEP=:)Mxc0", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
+{ "$(SYS)$(D)Mxc1-", "$(EVG)$(SEP=:)Mxc1", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
+{ "$(SYS)$(D)Mxc2-", "$(EVG)$(SEP=:)Mxc2", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
+{ "$(SYS)$(D)Mxc3-", "$(EVG)$(SEP=:)Mxc3", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
+{ "$(SYS)$(D)Mxc4-", "$(EVG)$(SEP=:)Mxc4", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
+{ "$(SYS)$(D)Mxc5-", "$(EVG)$(SEP=:)Mxc5", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
+{ "$(SYS)$(D)Mxc6-", "$(EVG)$(SEP=:)Mxc6", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
+{ "$(SYS)$(D)Mxc7-", "$(EVG)$(SEP=:)Mxc7", $(SYS), $(D), "$(SYS)$(D)", "$(SYS)$(D)EvtClk-" }
 }
 
 file mrmSoftSeq.template {
 pattern { P, PINITSEQ, PTRIGSRC, EVG, seqNum, NELM }
-{ "$(SYS)-$(D):SoftSeq0-", "$(SYS)-$(D):SoftSeq0-InitSeq-", "$(SYS)-$(D):SoftSeq0-TrigSrc-", "$(EVG)", 0, 2047 }
-{ "$(SYS)-$(D):SoftSeq1-", "$(SYS)-$(D):SoftSeq1-InitSeq-", "$(SYS)-$(D):SoftSeq1-TrigSrc-", "$(EVG)", 1, 2047 }
-{ "$(SYS)-$(D):SoftSeq2-", "$(SYS)-$(D):SoftSeq2-InitSeq-", "$(SYS)-$(D):SoftSeq2-TrigSrc-", "$(EVG)", 2, 2047 }
+{ "$(SYS)$(D)SoftSeq0-", "$(SYS)$(D)SoftSeq0-InitSeq-", "$(SYS)$(D)SoftSeq0-TrigSrc-", "$(EVG)", 0, 2047 }
+{ "$(SYS)$(D)SoftSeq1-", "$(SYS)$(D)SoftSeq1-InitSeq-", "$(SYS)$(D)SoftSeq1-TrigSrc-", "$(EVG)", 1, 2047 }
+{ "$(SYS)$(D)SoftSeq2-", "$(SYS)$(D)SoftSeq2-InitSeq-", "$(SYS)$(D)SoftSeq2-TrigSrc-", "$(EVG)", 2, 2047 }
 }
 
 file evgSoftSeq.template {
 pattern { P, PTRIGSRC, PEVTCLKFREQ, SYSDEVTCLK, EVG, seqNum, NELM }
-{ "$(SYS)-$(D):SoftSeq0-", "$(SYS)-$(D):SoftSeq0-TrigSrc-", "$(SYS)-$(D):SoftSeq0-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", $(EVG), 0, 2047 }
-{ "$(SYS)-$(D):SoftSeq1-", "$(SYS)-$(D):SoftSeq1-TrigSrc-", "$(SYS)-$(D):SoftSeq1-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", $(EVG), 1, 2047 }
-{ "$(SYS)-$(D):SoftSeq2-", "$(SYS)-$(D):SoftSeq2-TrigSrc-", "$(SYS)-$(D):SoftSeq2-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", $(EVG), 2, 2047 }
+{ "$(SYS)$(D)SoftSeq0-", "$(SYS)$(D)SoftSeq0-TrigSrc-", "$(SYS)$(D)SoftSeq0-EvtClkFreq-", "$(SYS)$(D)EvtClk-", $(EVG), 0, 2047 }
+{ "$(SYS)$(D)SoftSeq1-", "$(SYS)$(D)SoftSeq1-TrigSrc-", "$(SYS)$(D)SoftSeq1-EvtClkFreq-", "$(SYS)$(D)EvtClk-", $(EVG), 1, 2047 }
+{ "$(SYS)$(D)SoftSeq2-", "$(SYS)$(D)SoftSeq2-TrigSrc-", "$(SYS)$(D)SoftSeq2-EvtClkFreq-", "$(SYS)$(D)EvtClk-", $(EVG), 2, 2047 }
 }
 
 file evgTrigEvt.db {
 pattern { P, PTRIGSRC, POMSL, OBJ, EVG, trigEvtNum }
-{ "$(SYS)-$(D):TrigEvt0-", "$(SYS)-$(D):TrigEvt0-TrigSrc-", "$(SYS)-$(D):TrigEvt0-Omsl-", "$(EVG):TrigEvt0", $(EVG), 0 }
-{ "$(SYS)-$(D):TrigEvt1-", "$(SYS)-$(D):TrigEvt1-TrigSrc-", "$(SYS)-$(D):TrigEvt1-Omsl-", "$(EVG):TrigEvt1", $(EVG), 1 }
-{ "$(SYS)-$(D):TrigEvt2-", "$(SYS)-$(D):TrigEvt2-TrigSrc-", "$(SYS)-$(D):TrigEvt2-Omsl-", "$(EVG):TrigEvt2", $(EVG), 2 }
-{ "$(SYS)-$(D):TrigEvt3-", "$(SYS)-$(D):TrigEvt3-TrigSrc-", "$(SYS)-$(D):TrigEvt3-Omsl-", "$(EVG):TrigEvt3", $(EVG), 3 }
-{ "$(SYS)-$(D):TrigEvt4-", "$(SYS)-$(D):TrigEvt4-TrigSrc-", "$(SYS)-$(D):TrigEvt4-Omsl-", "$(EVG):TrigEvt4", $(EVG), 4 }
-{ "$(SYS)-$(D):TrigEvt5-", "$(SYS)-$(D):TrigEvt5-TrigSrc-", "$(SYS)-$(D):TrigEvt5-Omsl-", "$(EVG):TrigEvt5", $(EVG), 5 }
-{ "$(SYS)-$(D):TrigEvt6-", "$(SYS)-$(D):TrigEvt6-TrigSrc-", "$(SYS)-$(D):TrigEvt6-Omsl-", "$(EVG):TrigEvt6", $(EVG), 6 }
-{ "$(SYS)-$(D):TrigEvt7-", "$(SYS)-$(D):TrigEvt7-TrigSrc-", "$(SYS)-$(D):TrigEvt7-Omsl-", "$(EVG):TrigEvt7", $(EVG), 7 }
+{ "$(SYS)$(D)TrigEvt0-", "$(SYS)$(D)TrigEvt0-TrigSrc-", "$(SYS)$(D)TrigEvt0-Omsl-", "$(EVG)$(SEP=:)TrigEvt0", $(EVG), 0 }
+{ "$(SYS)$(D)TrigEvt1-", "$(SYS)$(D)TrigEvt1-TrigSrc-", "$(SYS)$(D)TrigEvt1-Omsl-", "$(EVG)$(SEP=:)TrigEvt1", $(EVG), 1 }
+{ "$(SYS)$(D)TrigEvt2-", "$(SYS)$(D)TrigEvt2-TrigSrc-", "$(SYS)$(D)TrigEvt2-Omsl-", "$(EVG)$(SEP=:)TrigEvt2", $(EVG), 2 }
+{ "$(SYS)$(D)TrigEvt3-", "$(SYS)$(D)TrigEvt3-TrigSrc-", "$(SYS)$(D)TrigEvt3-Omsl-", "$(EVG)$(SEP=:)TrigEvt3", $(EVG), 3 }
+{ "$(SYS)$(D)TrigEvt4-", "$(SYS)$(D)TrigEvt4-TrigSrc-", "$(SYS)$(D)TrigEvt4-Omsl-", "$(EVG)$(SEP=:)TrigEvt4", $(EVG), 4 }
+{ "$(SYS)$(D)TrigEvt5-", "$(SYS)$(D)TrigEvt5-TrigSrc-", "$(SYS)$(D)TrigEvt5-Omsl-", "$(EVG)$(SEP=:)TrigEvt5", $(EVG), 5 }
+{ "$(SYS)$(D)TrigEvt6-", "$(SYS)$(D)TrigEvt6-TrigSrc-", "$(SYS)$(D)TrigEvt6-Omsl-", "$(EVG)$(SEP=:)TrigEvt6", $(EVG), 6 }
+{ "$(SYS)$(D)TrigEvt7-", "$(SYS)$(D)TrigEvt7-TrigSrc-", "$(SYS)$(D)TrigEvt7-Omsl-", "$(EVG)$(SEP=:)TrigEvt7", $(EVG), 7 }
 }
 
 file databuftx.db
 {pattern
 { P, OBJ, PROTO }
-{ "$(SYS)-$(D):dbus-send-", "$(EVG):BUFTX", 1 }
+{ "$(SYS)$(D)dbus-send-", "$(EVG)$(SEP=:)BUFTX", 1 }
 }
 
 file "databuftxCtrl.db"
 {pattern
 { P, OBJ }
-{ "$(SYS)-$(D):Link-", "$(EVG):BUFTX" }
+{ "$(SYS)$(D)Link-", "$(EVG)$(SEP=:)BUFTX" }
 }
 

--- a/template/evr-mtca-300-ess.substitutions
+++ b/template/evr-mtca-300-ess.substitutions
@@ -7,266 +7,266 @@
 #  FEVT = Event link frequency (default 124.916 MHz)
 #
 # Record names have the general forms:
-#  $(SYS)-$(D):Signal-SD
-#  $(SYS)-$(D):SubDev-Signal-SD
+#  $(SYS)$(D)Signal-SD
+#  $(SYS)$(D)SubDev-Signal-SD
 
 file "evrbase.db"
 {
-{P="$(SYS)-$(D):", PCNT="$(SYS)-$(D):Cnt-", PLINK="$(SYS)-$(D):Link-", PRATE="$(SYS)-$(D):Rate-", PTIME="$(SYS)-$(D):Time-", OBJ="$(EVR)", OBJBUFRX="$(EVR):BUFRX", EVNT1HZ="\$(EVNT1HZ=125)", FEVT="\$(FEVT=124.916)"}
+{P="$(SYS)$(D)", PCNT="$(SYS)$(D)Cnt-", PLINK="$(SYS)$(D)Link-", PRATE="$(SYS)$(D)Rate-", PTIME="$(SYS)$(D)Time-", OBJ="$(EVR)", OBJBUFRX="$(EVR)$(SEP=:)BUFRX", EVNT1HZ="\$(EVNT1HZ=125)", FEVT="\$(FEVT=124.916)"}
 }
 
 file "databuftx.db"
 {pattern
 {P, OBJ, PROTO}
-{"$(SYS)-$(D):dbus-send-", "$(EVR):BUFTX", 1}
+{"$(SYS)$(D)dbus-send-", "$(EVR)$(SEP=:)BUFTX", 1}
 }
 
 file "evrSoftEvt.template"
 {
-{P="$(SYS)-$(D):", OBJ="$(EVR)"}
+{P="$(SYS)$(D)", OBJ="$(EVR)"}
 }
 
 file "databuftxCtrl.db"
 {pattern
 {P, OBJ}
-{"$(SYS)-$(D):Link-", "$(EVR):BUFTX"}
+{"$(SYS)$(D)Link-", "$(EVR)$(SEP=:)BUFTX"}
 }
 
 file "mrmevrbufrx.db"
 {pattern
 {P, OBJ, PROTO}
-{"$(SYS)-$(D):dbus-recv-", $(EVR):BUFRX, 0xff00}
+{"$(SYS)$(D)dbus-recv-", $(EVR)$(SEP=:)BUFRX, 0xff00}
 }
 
 file mrmSoftSeq.template {
 pattern { P, PINITSEQ, PTRIGSRC, EVG, seqNum, NELM }
-{ "$(SYS)-$(D):SoftSeq0-", "$(SYS)-$(D):SoftSeq0-InitSeq-", "$(SYS)-$(D):SoftSeq0-TrigSrc-", "$(EVR)", 0, 2047 }
-{ "$(SYS)-$(D):SoftSeq1-", "$(SYS)-$(D):SoftSeq1-InitSeq-", "$(SYS)-$(D):SoftSeq1-TrigSrc-", "$(EVR)", 1, 2047 }
-{ "$(SYS)-$(D):SoftSeq2-", "$(SYS)-$(D):SoftSeq2-InitSeq-", "$(SYS)-$(D):SoftSeq2-TrigSrc-", "$(EVR)", 2, 2047 }
+{ "$(SYS)$(D)SoftSeq0-", "$(SYS)$(D)SoftSeq0-InitSeq-", "$(SYS)$(D)SoftSeq0-TrigSrc-", "$(EVR)", 0, 2047 }
+{ "$(SYS)$(D)SoftSeq1-", "$(SYS)$(D)SoftSeq1-InitSeq-", "$(SYS)$(D)SoftSeq1-TrigSrc-", "$(EVR)", 1, 2047 }
+{ "$(SYS)$(D)SoftSeq2-", "$(SYS)$(D)SoftSeq2-InitSeq-", "$(SYS)$(D)SoftSeq2-TrigSrc-", "$(EVR)", 2, 2047 }
 }
 
 file evrSoftSeq.template {
 pattern { P, PTRIGSRC, PEVTCLKFREQ, SYSDEVTCLK, EVG, seqNum, NELM }
-{ "$(SYS)-$(D):SoftSeq0-", "$(SYS)-$(D):SoftSeq0-TrigSrc-", "$(SYS)-$(D):SoftSeq0-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", "$(EVR)", 0, 2047 }
-{ "$(SYS)-$(D):SoftSeq1-", "$(SYS)-$(D):SoftSeq1-TrigSrc-", "$(SYS)-$(D):SoftSeq1-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", "$(EVR)", 1, 2047 }
-{ "$(SYS)-$(D):SoftSeq2-", "$(SYS)-$(D):SoftSeq2-TrigSrc-", "$(SYS)-$(D):SoftSeq2-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", "$(EVR)", 2, 2047 }
+{ "$(SYS)$(D)SoftSeq0-", "$(SYS)$(D)SoftSeq0-TrigSrc-", "$(SYS)$(D)SoftSeq0-EvtClkFreq-", "$(SYS)$(D)EvtClk-", "$(EVR)", 0, 2047 }
+{ "$(SYS)$(D)SoftSeq1-", "$(SYS)$(D)SoftSeq1-TrigSrc-", "$(SYS)$(D)SoftSeq1-EvtClkFreq-", "$(SYS)$(D)EvtClk-", "$(EVR)", 1, 2047 }
+{ "$(SYS)$(D)SoftSeq2-", "$(SYS)$(D)SoftSeq2-TrigSrc-", "$(SYS)$(D)SoftSeq2-EvtClkFreq-", "$(SYS)$(D)EvtClk-", "$(EVR)", 2, 2047 }
 }
 
 file "sfp.db"
 {
-{P="$(SYS)-$(D):SFP-", PPWR="$(SYS)-$(D):SFP-Pwr-", PSPEED="$(SYS)-$(D):SFP-Speed-", PDATE="$(SYS)-$(D):SFP-Date-", OBJ="$(EVR):SFP"}
+{P="$(SYS)$(D)SFP-", PPWR="$(SYS)$(D)SFP-Pwr-", PSPEED="$(SYS)$(D)SFP-Speed-", PDATE="$(SYS)$(D)SFP-Date-", OBJ="$(EVR)$(SEP=:)SFP"}
 }
 
 file "mrmevrdc.template"
 {
-{P="$(SYS)-$(D):DC-", OBJ="$(EVR)"}
+{P="$(SYS)$(D)DC-", OBJ="$(EVR)"}
 }
 
 file "evrmap.db"
 {pattern
 {NAME, OBJ, func, EVT}
-{"$(SYS)-$(D):Evt-Blink0-SP", "$(EVR)", Blink, 15}
-{"$(SYS)-$(D):Evt-Blink1-SP", "$(EVR)", Blink, 0}
-{"$(SYS)-$(D):Evt-ResetPS-SP","$(EVR)", "Reset PS", 123}
+{"$(SYS)$(D)Evt-Blink0-SP", "$(EVR)", Blink, 15}
+{"$(SYS)$(D)Evt-Blink1-SP", "$(EVR)", Blink, 0}
+{"$(SYS)$(D)Evt-ResetPS-SP","$(EVR)", "Reset PS", 123}
 }
 
 file "evrevent.db"
 {pattern
 {EN, OBJ, CODE, EVNT}
-{"$(SYS)-$(D):1hz",  "$(EVR)", 0x7d, 125}
-{"$(SYS)-$(D):EvtA", "$(EVR)", 10, 10}
-{"$(SYS)-$(D):EvtB", "$(EVR)", 11, 11}
-{"$(SYS)-$(D):EvtC", "$(EVR)", 12, 12}
-{"$(SYS)-$(D):EvtD", "$(EVR)", 13, 13}
-{"$(SYS)-$(D):EvtE", "$(EVR)", 14, 14}
-{"$(SYS)-$(D):EvtF", "$(EVR)", 15, 15}
-{"$(SYS)-$(D):EvtG", "$(EVR)", 16, 16}
-{"$(SYS)-$(D):EvtH", "$(EVR)", 17, 17}
+{"$(SYS)$(D)1hz",  "$(EVR)", 0x7d, 125}
+{"$(SYS)$(D)EvtA", "$(EVR)", 10, 10}
+{"$(SYS)$(D)EvtB", "$(EVR)", 11, 11}
+{"$(SYS)$(D)EvtC", "$(EVR)", 12, 12}
+{"$(SYS)$(D)EvtD", "$(EVR)", 13, 13}
+{"$(SYS)$(D)EvtE", "$(EVR)", 14, 14}
+{"$(SYS)$(D)EvtF", "$(EVR)", 15, 15}
+{"$(SYS)$(D)EvtG", "$(EVR)", 16, 16}
+{"$(SYS)$(D)EvtH", "$(EVR)", 17, 17}
 }
 
 file "evrscale.db"
 {pattern
 {IDX, P, SN, OBJ, MAX}
-{0, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{1, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{2, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{3, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{4, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{5, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{6, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{7, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
+{0, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{1, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{2, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{3, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{4, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{5, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{6, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{7, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
 }
 
 file "mrmevrout.db"
 {pattern
 {ON, ONSRC, OBJ, DESC}
-{"$(SYS)-$(D):OutInt-", "$(SYS)-$(D):OutInt-Src-", "$(EVR):Int", "Internal"}
-{"$(SYS)-$(D):OutFP0-", "$(SYS)-$(D):OutFP0-Src-", "$(EVR):FrontOut0", "OUT0 (TTL)"}
-{"$(SYS)-$(D):OutFP1-", "$(SYS)-$(D):OutFP1-Src-", "$(EVR):FrontOut1", "OUT1 (TTL)"}
-{"$(SYS)-$(D):OutFP2-", "$(SYS)-$(D):OutFP2-Src-", "$(EVR):FrontOut2", "OUT2 (TTL)"}
-{"$(SYS)-$(D):OutFP3-", "$(SYS)-$(D):OutFP3-Src-", "$(EVR):FrontOut3", "OUT3 (TTL)"}
+{"$(SYS)$(D)OutInt-", "$(SYS)$(D)OutInt-Src-", "$(EVR)$(SEP=:)Int", "Internal"}
+{"$(SYS)$(D)OutFP0-", "$(SYS)$(D)OutFP0-Src-", "$(EVR)$(SEP=:)FrontOut0", "OUT0 (TTL)"}
+{"$(SYS)$(D)OutFP1-", "$(SYS)$(D)OutFP1-Src-", "$(EVR)$(SEP=:)FrontOut1", "OUT1 (TTL)"}
+{"$(SYS)$(D)OutFP2-", "$(SYS)$(D)OutFP2-Src-", "$(EVR)$(SEP=:)FrontOut2", "OUT2 (TTL)"}
+{"$(SYS)$(D)OutFP3-", "$(SYS)$(D)OutFP3-Src-", "$(EVR)$(SEP=:)FrontOut3", "OUT3 (TTL)"}
 # default to tri-state for IFB and backplane lines
 pattern
 {ON, ONSRC, OBJ, DESC, DEFAULT}
-{"$(SYS)-$(D):OutFPUV00-", "$(SYS)-$(D):OutFPUV00-Src-", "$(EVR):FrontUnivOut0", "UNIV0", 61}
-{"$(SYS)-$(D):OutFPUV01-", "$(SYS)-$(D):OutFPUV01-Src-", "$(EVR):FrontUnivOut1", "UNIV1", 61}
-{"$(SYS)-$(D):OutFPUV02-", "$(SYS)-$(D):OutFPUV02-Src-", "$(EVR):FrontUnivOut2", "UNIV2", 61}
-{"$(SYS)-$(D):OutFPUV03-", "$(SYS)-$(D):OutFPUV03-Src-", "$(EVR):FrontUnivOut3", "UNIV3", 61}
-{"$(SYS)-$(D):OutFPUV04-", "$(SYS)-$(D):OutFPUV04-Src-", "$(EVR):FrontUnivOut4", "UNIV4", 61}
-{"$(SYS)-$(D):OutFPUV05-", "$(SYS)-$(D):OutFPUV05-Src-", "$(EVR):FrontUnivOut5", "UNIV5", 61}
-{"$(SYS)-$(D):OutFPUV06-", "$(SYS)-$(D):OutFPUV06-Src-", "$(EVR):FrontUnivOut6", "UNIV6", 61}
-{"$(SYS)-$(D):OutFPUV07-", "$(SYS)-$(D):OutFPUV07-Src-", "$(EVR):FrontUnivOut7", "UNIV7", 61}
-{"$(SYS)-$(D):OutFPUV08-", "$(SYS)-$(D):OutFPUV08-Src-", "$(EVR):FrontUnivOut8", "UNIV8", 61}
-{"$(SYS)-$(D):OutFPUV09-", "$(SYS)-$(D):OutFPUV09-Src-", "$(EVR):FrontUnivOut9", "UNIV9", 61}
-{"$(SYS)-$(D):OutFPUV10-", "$(SYS)-$(D):OutFPUV10-Src-", "$(EVR):FrontUnivOut10","UNIV10", 61}
-{"$(SYS)-$(D):OutFPUV11-", "$(SYS)-$(D):OutFPUV11-Src-", "$(EVR):FrontUnivOut11","UNIV11", 61}
-{"$(SYS)-$(D):OutFPUV12-", "$(SYS)-$(D):OutFPUV12-Src-", "$(EVR):FrontUnivOut12","UNIV12", 61}
-{"$(SYS)-$(D):OutFPUV13-", "$(SYS)-$(D):OutFPUV13-Src-", "$(EVR):FrontUnivOut13","UNIV13", 61}
-{"$(SYS)-$(D):OutFPUV14-", "$(SYS)-$(D):OutFPUV14-Src-", "$(EVR):FrontUnivOut14","UNIV14", 61}
-{"$(SYS)-$(D):OutFPUV15-", "$(SYS)-$(D):OutFPUV15-Src-", "$(EVR):FrontUnivOut15","UNIV15", 61}
-{"$(SYS)-$(D):OutBack0-", "$(SYS)-$(D):OutBack0-Src-", "$(EVR):Backplane0", "RX17 (0)", 61}
-{"$(SYS)-$(D):OutBack1-", "$(SYS)-$(D):OutBack1-Src-", "$(EVR):Backplane1", "TX17 (1)", 61}
-{"$(SYS)-$(D):OutBack2-", "$(SYS)-$(D):OutBack2-Src-", "$(EVR):Backplane2", "RX18 (2)", 61}
-{"$(SYS)-$(D):OutBack3-", "$(SYS)-$(D):OutBack3-Src-", "$(EVR):Backplane3", "TX18 (3)", 61}
-{"$(SYS)-$(D):OutBack4-", "$(SYS)-$(D):OutBack4-Src-", "$(EVR):Backplane4", "RX19 (4)", 61}
-{"$(SYS)-$(D):OutBack5-", "$(SYS)-$(D):OutBack5-Src-", "$(EVR):Backplane5", "TX19 (5)", 61}
-{"$(SYS)-$(D):OutBack6-", "$(SYS)-$(D):OutBack6-Src-", "$(EVR):Backplane6", "RX20 (6)", 61}
-{"$(SYS)-$(D):OutBack7-", "$(SYS)-$(D):OutBack7-Src-", "$(EVR):Backplane7", "TX20 (7)", 61}
-{"$(SYS)-$(D):OutTCLKA-", "$(SYS)-$(D):OutTCLKA-Src-", "$(EVR):FrontUnivOut16", "TCLKA", 61}
-{"$(SYS)-$(D):OutTCLKB-", "$(SYS)-$(D):OutTCLKB-Src-", "$(EVR):FrontUnivOut17", "TCLKB", 61}
+{"$(SYS)$(D)OutFPUV00-", "$(SYS)$(D)OutFPUV00-Src-", "$(EVR)$(SEP=:)FrontUnivOut0", "UNIV0", 61}
+{"$(SYS)$(D)OutFPUV01-", "$(SYS)$(D)OutFPUV01-Src-", "$(EVR)$(SEP=:)FrontUnivOut1", "UNIV1", 61}
+{"$(SYS)$(D)OutFPUV02-", "$(SYS)$(D)OutFPUV02-Src-", "$(EVR)$(SEP=:)FrontUnivOut2", "UNIV2", 61}
+{"$(SYS)$(D)OutFPUV03-", "$(SYS)$(D)OutFPUV03-Src-", "$(EVR)$(SEP=:)FrontUnivOut3", "UNIV3", 61}
+{"$(SYS)$(D)OutFPUV04-", "$(SYS)$(D)OutFPUV04-Src-", "$(EVR)$(SEP=:)FrontUnivOut4", "UNIV4", 61}
+{"$(SYS)$(D)OutFPUV05-", "$(SYS)$(D)OutFPUV05-Src-", "$(EVR)$(SEP=:)FrontUnivOut5", "UNIV5", 61}
+{"$(SYS)$(D)OutFPUV06-", "$(SYS)$(D)OutFPUV06-Src-", "$(EVR)$(SEP=:)FrontUnivOut6", "UNIV6", 61}
+{"$(SYS)$(D)OutFPUV07-", "$(SYS)$(D)OutFPUV07-Src-", "$(EVR)$(SEP=:)FrontUnivOut7", "UNIV7", 61}
+{"$(SYS)$(D)OutFPUV08-", "$(SYS)$(D)OutFPUV08-Src-", "$(EVR)$(SEP=:)FrontUnivOut8", "UNIV8", 61}
+{"$(SYS)$(D)OutFPUV09-", "$(SYS)$(D)OutFPUV09-Src-", "$(EVR)$(SEP=:)FrontUnivOut9", "UNIV9", 61}
+{"$(SYS)$(D)OutFPUV10-", "$(SYS)$(D)OutFPUV10-Src-", "$(EVR)$(SEP=:)FrontUnivOut10","UNIV10", 61}
+{"$(SYS)$(D)OutFPUV11-", "$(SYS)$(D)OutFPUV11-Src-", "$(EVR)$(SEP=:)FrontUnivOut11","UNIV11", 61}
+{"$(SYS)$(D)OutFPUV12-", "$(SYS)$(D)OutFPUV12-Src-", "$(EVR)$(SEP=:)FrontUnivOut12","UNIV12", 61}
+{"$(SYS)$(D)OutFPUV13-", "$(SYS)$(D)OutFPUV13-Src-", "$(EVR)$(SEP=:)FrontUnivOut13","UNIV13", 61}
+{"$(SYS)$(D)OutFPUV14-", "$(SYS)$(D)OutFPUV14-Src-", "$(EVR)$(SEP=:)FrontUnivOut14","UNIV14", 61}
+{"$(SYS)$(D)OutFPUV15-", "$(SYS)$(D)OutFPUV15-Src-", "$(EVR)$(SEP=:)FrontUnivOut15","UNIV15", 61}
+{"$(SYS)$(D)OutBack0-", "$(SYS)$(D)OutBack0-Src-", "$(EVR)$(SEP=:)Backplane0", "RX17 (0)", 61}
+{"$(SYS)$(D)OutBack1-", "$(SYS)$(D)OutBack1-Src-", "$(EVR)$(SEP=:)Backplane1", "TX17 (1)", 61}
+{"$(SYS)$(D)OutBack2-", "$(SYS)$(D)OutBack2-Src-", "$(EVR)$(SEP=:)Backplane2", "RX18 (2)", 61}
+{"$(SYS)$(D)OutBack3-", "$(SYS)$(D)OutBack3-Src-", "$(EVR)$(SEP=:)Backplane3", "TX18 (3)", 61}
+{"$(SYS)$(D)OutBack4-", "$(SYS)$(D)OutBack4-Src-", "$(EVR)$(SEP=:)Backplane4", "RX19 (4)", 61}
+{"$(SYS)$(D)OutBack5-", "$(SYS)$(D)OutBack5-Src-", "$(EVR)$(SEP=:)Backplane5", "TX19 (5)", 61}
+{"$(SYS)$(D)OutBack6-", "$(SYS)$(D)OutBack6-Src-", "$(EVR)$(SEP=:)Backplane6", "RX20 (6)", 61}
+{"$(SYS)$(D)OutBack7-", "$(SYS)$(D)OutBack7-Src-", "$(EVR)$(SEP=:)Backplane7", "TX20 (7)", 61}
+{"$(SYS)$(D)OutTCLKA-", "$(SYS)$(D)OutTCLKA-Src-", "$(EVR)$(SEP=:)FrontUnivOut16", "TCLKA", 61}
+{"$(SYS)$(D)OutTCLKB-", "$(SYS)$(D)OutTCLKB-Src-", "$(EVR)$(SEP=:)FrontUnivOut17", "TCLKB", 61}
 }
 
 file "mrmevroutint.db"
 {{
-    ON="$(SYS)-$(D):OutInt-", OBJ="$(EVR)"
+    ON="$(SYS)$(D)OutInt-", OBJ="$(EVR)"
 }}
 
 file "evrcml.db"
 {pattern
 {PLINK, ON, ONFREQ, ONPAT, ONWFCALC, ONBT, OBJ}
-{"$(SYS)-$(D):Link-", "$(SYS)-$(D):OutTCLKA-", "$(SYS)-$(D):OutTCLKA-Freq-", "$(SYS)-$(D):OutTCLKA-Pat-", "$(SYS)-$(D):OutTCLKA-WfCalc-", "$(SYS)-$(D):OutTCLKA-BunchTrain-", "$(EVR):CML0"}
-{"$(SYS)-$(D):Link-", "$(SYS)-$(D):OutTCLKB-", "$(SYS)-$(D):OutTCLKB-Freq-", "$(SYS)-$(D):OutTCLKB-Pat-", "$(SYS)-$(D):OutTCLKB-WfCalc-", "$(SYS)-$(D):OutTCLKB-BunchTrain-", "$(EVR):CML1"}
+{"$(SYS)$(D)Link-", "$(SYS)$(D)OutTCLKA-", "$(SYS)$(D)OutTCLKA-Freq-", "$(SYS)$(D)OutTCLKA-Pat-", "$(SYS)$(D)OutTCLKA-WfCalc-", "$(SYS)$(D)OutTCLKA-BunchTrain-", "$(EVR)$(SEP=:)CML0"}
+{"$(SYS)$(D)Link-", "$(SYS)$(D)OutTCLKB-", "$(SYS)$(D)OutTCLKB-Freq-", "$(SYS)$(D)OutTCLKB-Pat-", "$(SYS)$(D)OutTCLKB-WfCalc-", "$(SYS)$(D)OutTCLKB-BunchTrain-", "$(EVR)$(SEP=:)CML1"}
 }
 
 # Pulse generators w/o a prescaler set NOPS=1
 file "evrpulser.db"
 {pattern
 {PID, P, PLINK, PN, PNDELAY, PNWIDTH, OBJ, DMAX, WMAX, PMAX, NOPS}
-{0, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
-{1, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
-{2, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
-{3, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
-{4, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{5, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{6, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{7, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{8, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{9, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{10,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{11,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{12,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{13,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{14,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{15,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{0, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{1, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{2, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{3, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{4, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{5, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{6, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{7, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{8, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{9, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{10,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{11,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{12,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{13,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{14,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{15,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
 # gate generators
-{28,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{29,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{30,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{31,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{28,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{29,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{30,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{31,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
 }
 
 # Default to 3 possible trigger mappings per pulser
 file "evrpulsermap.db"
 {pattern
 {PID, NAME, OBJ, F, EVT}
-{0, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{0, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{0, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{1, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{1, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{1, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{2, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{2, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{2, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{3, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{3, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{3, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{4, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{4, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{4, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{5, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{5, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{5, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{6, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{6, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{6, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{7, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{7, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{7, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{8, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{8, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{8, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{9, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{9, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{9, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{10,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{10,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{10,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{11,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{11,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{11,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{12,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{12,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{12,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{13,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{13,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{13,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{14,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{14,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{14,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{15,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{15,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{15,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{0, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{0, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{0, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{1, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{1, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{1, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{2, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{2, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{2, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{3, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{3, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{3, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{4, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{4, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{4, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{5, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{5, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{5, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{6, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{6, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{6, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{7, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{7, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{7, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{8, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{8, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{8, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{9, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{9, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{9, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{10,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{10,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{10,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{11,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{11,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{11,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{12,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{12,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{12,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{13,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{13,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{13,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{14,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{14,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{14,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{15,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{15,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{15,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
 # gate generators mappings
-{28,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{28,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{28,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{29,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{29,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{29,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{30,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{30,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{30,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{31,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{31,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{31,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{28,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{28,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{28,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{29,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{29,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{29,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{30,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{30,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{30,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{31,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{31,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{31,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
 }
 
 # pulser masking controls
 file "evrdcpulser.template"
 {pattern
 {PID, P, PN, OBJ}
-{0, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{1, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{2, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{3, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{4, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{5, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{6, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{7, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{8, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{9, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{10, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{11, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{12, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{13, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{14, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{15, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
+{0, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{1, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{2, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{3, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{4, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{5, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{6, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{7, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{8, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{9, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{10, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{11, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{12, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{13, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{14, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{15, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
 }
 
 file "evrin.db"
 {pattern
 {IN, INTRIG, INCODE, OBJ, DESC}
-{"$(SYS)-$(D):In0-", "$(SYS)-$(D):In0-Trig-", "$(SYS)-$(D):In0-Code-", "$(EVR):FPIn0", "IN0 (TTL)"}
-{"$(SYS)-$(D):In1-", "$(SYS)-$(D):In1-Trig-", "$(SYS)-$(D):In1-Code-", "$(EVR):FPIn1", "IN1 (TTL)"}
+{"$(SYS)$(D)In0-", "$(SYS)$(D)In0-Trig-", "$(SYS)$(D)In0-Code-", "$(EVR)$(SEP=:)FPIn0", "IN0 (TTL)"}
+{"$(SYS)$(D)In1-", "$(SYS)$(D)In1-Trig-", "$(SYS)$(D)In1-Code-", "$(EVR)$(SEP=:)FPIn1", "IN1 (TTL)"}
 }

--- a/template/evr-mtca-300u-ess.substitutions
+++ b/template/evr-mtca-300u-ess.substitutions
@@ -7,254 +7,254 @@
 #  FEVT = Event link frequency (default 124.916 MHz)
 #
 # Record names have the general forms:
-#  $(SYS)-$(D):Signal-SD
-#  $(SYS)-$(D):SubDev-Signal-SD
+#  $(SYS)$(D)Signal-SD
+#  $(SYS)$(D)SubDev-Signal-SD
 
 file "evrbase.db"
 {
-{P="$(SYS)-$(D):", PCNT="$(SYS)-$(D):Cnt-", PLINK="$(SYS)-$(D):Link-", PRATE="$(SYS)-$(D):Rate-", PTIME="$(SYS)-$(D):Time-", OBJ="$(EVR)", OBJBUFRX="$(EVR):BUFRX", EVNT1HZ="\$(EVNT1HZ=125)", FEVT="\$(FEVT=124.916)"}
+{P="$(SYS)$(D)", PCNT="$(SYS)$(D)Cnt-", PLINK="$(SYS)$(D)Link-", PRATE="$(SYS)$(D)Rate-", PTIME="$(SYS)$(D)Time-", OBJ="$(EVR)", OBJBUFRX="$(EVR)$(SEP=:)BUFRX", EVNT1HZ="\$(EVNT1HZ=125)", FEVT="\$(FEVT=124.916)"}
 }
 
 file "databuftx.db"
 {pattern
 {P, OBJ, PROTO}
-{"$(SYS)-$(D):dbus-send-", "$(EVR):BUFTX", 1}
+{"$(SYS)$(D)dbus-send-", "$(EVR)$(SEP=:)BUFTX", 1}
 }
 
 file "evrSoftEvt.template"
 {
-{P="$(SYS)-$(D):", OBJ="$(EVR)"}
+{P="$(SYS)$(D)", OBJ="$(EVR)"}
 }
 
 file "databuftxCtrl.db"
 {pattern
 {P, OBJ}
-{"$(SYS)-$(D):Link-", "$(EVR):BUFTX"}
+{"$(SYS)$(D)Link-", "$(EVR)$(SEP=:)BUFTX"}
 }
 
 file "mrmevrbufrx.db"
 {pattern
 {P, OBJ, PROTO}
-{"$(SYS)-$(D):dbus-recv-", $(EVR):BUFRX, 0xff00}
+{"$(SYS)$(D)dbus-recv-", $(EVR)$(SEP=:)BUFRX, 0xff00}
 }
 
 file mrmSoftSeq.template {
 pattern { P, PINITSEQ, PTRIGSRC, EVG, seqNum, NELM }
-{ "$(SYS)-$(D):SoftSeq0-", "$(SYS)-$(D):SoftSeq0-InitSeq-", "$(SYS)-$(D):SoftSeq0-TrigSrc-", "$(EVR)", 0, 2047 }
-{ "$(SYS)-$(D):SoftSeq1-", "$(SYS)-$(D):SoftSeq1-InitSeq-", "$(SYS)-$(D):SoftSeq1-TrigSrc-", "$(EVR)", 1, 2047 }
-{ "$(SYS)-$(D):SoftSeq2-", "$(SYS)-$(D):SoftSeq2-InitSeq-", "$(SYS)-$(D):SoftSeq2-TrigSrc-", "$(EVR)", 2, 2047 }
+{ "$(SYS)$(D)SoftSeq0-", "$(SYS)$(D)SoftSeq0-InitSeq-", "$(SYS)$(D)SoftSeq0-TrigSrc-", "$(EVR)", 0, 2047 }
+{ "$(SYS)$(D)SoftSeq1-", "$(SYS)$(D)SoftSeq1-InitSeq-", "$(SYS)$(D)SoftSeq1-TrigSrc-", "$(EVR)", 1, 2047 }
+{ "$(SYS)$(D)SoftSeq2-", "$(SYS)$(D)SoftSeq2-InitSeq-", "$(SYS)$(D)SoftSeq2-TrigSrc-", "$(EVR)", 2, 2047 }
 }
 
 file evrSoftSeq.template {
 pattern { P, PTRIGSRC, PEVTCLKFREQ, SYSDEVTCLK, EVG, seqNum, NELM }
-{ "$(SYS)-$(D):SoftSeq0-", "$(SYS)-$(D):SoftSeq0-TrigSrc-", "$(SYS)-$(D):SoftSeq0-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", "$(EVR)", 0, 2047 }
-{ "$(SYS)-$(D):SoftSeq1-", "$(SYS)-$(D):SoftSeq1-TrigSrc-", "$(SYS)-$(D):SoftSeq1-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", "$(EVR)", 1, 2047 }
-{ "$(SYS)-$(D):SoftSeq2-", "$(SYS)-$(D):SoftSeq2-TrigSrc-", "$(SYS)-$(D):SoftSeq2-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", "$(EVR)", 2, 2047 }
+{ "$(SYS)$(D)SoftSeq0-", "$(SYS)$(D)SoftSeq0-TrigSrc-", "$(SYS)$(D)SoftSeq0-EvtClkFreq-", "$(SYS)$(D)EvtClk-", "$(EVR)", 0, 2047 }
+{ "$(SYS)$(D)SoftSeq1-", "$(SYS)$(D)SoftSeq1-TrigSrc-", "$(SYS)$(D)SoftSeq1-EvtClkFreq-", "$(SYS)$(D)EvtClk-", "$(EVR)", 1, 2047 }
+{ "$(SYS)$(D)SoftSeq2-", "$(SYS)$(D)SoftSeq2-TrigSrc-", "$(SYS)$(D)SoftSeq2-EvtClkFreq-", "$(SYS)$(D)EvtClk-", "$(EVR)", 2, 2047 }
 }
 
 file "sfp.db"
 {
-{P="$(SYS)-$(D):SFP-", PPWR="$(SYS)-$(D):SFP-Pwr-", PSPEED="$(SYS)-$(D):SFP-Speed-", PDATE="$(SYS)-$(D):SFP-Date-", OBJ="$(EVR):SFP"}
+{P="$(SYS)$(D)SFP-", PPWR="$(SYS)$(D)SFP-Pwr-", PSPEED="$(SYS)$(D)SFP-Speed-", PDATE="$(SYS)$(D)SFP-Date-", OBJ="$(EVR)$(SEP=:)SFP"}
 }
 
 file "mrmevrdc.template"
 {
-{P="$(SYS)-$(D):DC-", OBJ="$(EVR)"}
+{P="$(SYS)$(D)DC-", OBJ="$(EVR)"}
 }
 
 file "evrmap.db"
 {pattern
 {NAME, OBJ, func, EVT}
-{"$(SYS)-$(D):Evt-Blink0-SP", "$(EVR)", Blink, 15}
-{"$(SYS)-$(D):Evt-Blink1-SP", "$(EVR)", Blink, 0}
-{"$(SYS)-$(D):Evt-ResetPS-SP","$(EVR)", "Reset PS", 123}
+{"$(SYS)$(D)Evt-Blink0-SP", "$(EVR)", Blink, 15}
+{"$(SYS)$(D)Evt-Blink1-SP", "$(EVR)", Blink, 0}
+{"$(SYS)$(D)Evt-ResetPS-SP","$(EVR)", "Reset PS", 123}
 }
 
 file "evrevent.db"
 {pattern
 {EN, OBJ, CODE, EVNT}
-{"$(SYS)-$(D):1hz",  "$(EVR)", 0x7d, 125}
-{"$(SYS)-$(D):EvtA", "$(EVR)", 10, 10}
-{"$(SYS)-$(D):EvtB", "$(EVR)", 11, 11}
-{"$(SYS)-$(D):EvtC", "$(EVR)", 12, 12}
-{"$(SYS)-$(D):EvtD", "$(EVR)", 13, 13}
-{"$(SYS)-$(D):EvtE", "$(EVR)", 14, 14}
-{"$(SYS)-$(D):EvtF", "$(EVR)", 15, 15}
-{"$(SYS)-$(D):EvtG", "$(EVR)", 16, 16}
-{"$(SYS)-$(D):EvtH", "$(EVR)", 17, 17}
+{"$(SYS)$(D)1hz",  "$(EVR)", 0x7d, 125}
+{"$(SYS)$(D)EvtA", "$(EVR)", 10, 10}
+{"$(SYS)$(D)EvtB", "$(EVR)", 11, 11}
+{"$(SYS)$(D)EvtC", "$(EVR)", 12, 12}
+{"$(SYS)$(D)EvtD", "$(EVR)", 13, 13}
+{"$(SYS)$(D)EvtE", "$(EVR)", 14, 14}
+{"$(SYS)$(D)EvtF", "$(EVR)", 15, 15}
+{"$(SYS)$(D)EvtG", "$(EVR)", 16, 16}
+{"$(SYS)$(D)EvtH", "$(EVR)", 17, 17}
 }
 
 file "evrscale.db"
 {pattern
 {IDX, P, SN, OBJ, MAX}
-{0, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{1, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{2, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{3, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{4, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{5, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{6, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{7, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
+{0, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{1, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{2, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{3, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{4, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{5, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{6, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{7, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
 }
 
 file "mrmevrout.db"
 {pattern
 {ON, ONSRC, OBJ, DESC}
-{"$(SYS)-$(D):OutInt-", "$(SYS)-$(D):OutInt-Src-", "$(EVR):Int", "Internal"}
-{"$(SYS)-$(D):OutFP0-", "$(SYS)-$(D):OutFP0-Src-", "$(EVR):FrontOut0", "OUT0 (TTL)"}
-{"$(SYS)-$(D):OutFP1-", "$(SYS)-$(D):OutFP1-Src-", "$(EVR):FrontOut1", "OUT1 (TTL)"}
-{"$(SYS)-$(D):OutFP2-", "$(SYS)-$(D):OutFP2-Src-", "$(EVR):FrontOut2", "OUT2 (TTL)"}
-{"$(SYS)-$(D):OutFP3-", "$(SYS)-$(D):OutFP3-Src-", "$(EVR):FrontOut3", "OUT3 (TTL)"}
+{"$(SYS)$(D)OutInt-", "$(SYS)$(D)OutInt-Src-", "$(EVR)$(SEP=:)Int", "Internal"}
+{"$(SYS)$(D)OutFP0-", "$(SYS)$(D)OutFP0-Src-", "$(EVR)$(SEP=:)FrontOut0", "OUT0 (TTL)"}
+{"$(SYS)$(D)OutFP1-", "$(SYS)$(D)OutFP1-Src-", "$(EVR)$(SEP=:)FrontOut1", "OUT1 (TTL)"}
+{"$(SYS)$(D)OutFP2-", "$(SYS)$(D)OutFP2-Src-", "$(EVR)$(SEP=:)FrontOut2", "OUT2 (TTL)"}
+{"$(SYS)$(D)OutFP3-", "$(SYS)$(D)OutFP3-Src-", "$(EVR)$(SEP=:)FrontOut3", "OUT3 (TTL)"}
 # default to tri-state for IFB and backplane lines
 pattern
 {ON, ONSRC, OBJ, DESC, DEFAULT}
-{"$(SYS)-$(D):OutFPUV0-", "$(SYS)-$(D):OutFPUV0-Src-", "$(EVR):FrontUnivOut0", "UNIV0", 61}
-{"$(SYS)-$(D):OutFPUV1-", "$(SYS)-$(D):OutFPUV1-Src-", "$(EVR):FrontUnivOut1", "UNIV1", 61}
-{"$(SYS)-$(D):OutFPUV2-", "$(SYS)-$(D):OutFPUV2-Src-", "$(EVR):FrontUnivOut2", "UNIV2", 61}
-{"$(SYS)-$(D):OutFPUV3-", "$(SYS)-$(D):OutFPUV3-Src-", "$(EVR):FrontUnivOut3", "UNIV3", 61}
-{"$(SYS)-$(D):OutBack0-", "$(SYS)-$(D):OutBack0-Src-", "$(EVR):Backplane0", "RX17 (0)", 61}
-{"$(SYS)-$(D):OutBack1-", "$(SYS)-$(D):OutBack1-Src-", "$(EVR):Backplane1", "TX17 (1)", 61}
-{"$(SYS)-$(D):OutBack2-", "$(SYS)-$(D):OutBack2-Src-", "$(EVR):Backplane2", "RX18 (2)", 61}
-{"$(SYS)-$(D):OutBack3-", "$(SYS)-$(D):OutBack3-Src-", "$(EVR):Backplane3", "TX18 (3)", 61}
-{"$(SYS)-$(D):OutBack4-", "$(SYS)-$(D):OutBack4-Src-", "$(EVR):Backplane4", "RX19 (4)", 61}
-{"$(SYS)-$(D):OutBack5-", "$(SYS)-$(D):OutBack5-Src-", "$(EVR):Backplane5", "TX19 (5)", 61}
-{"$(SYS)-$(D):OutBack6-", "$(SYS)-$(D):OutBack6-Src-", "$(EVR):Backplane6", "RX20 (6)", 61}
-{"$(SYS)-$(D):OutBack7-", "$(SYS)-$(D):OutBack7-Src-", "$(EVR):Backplane7", "TX20 (7)", 61}
-{"$(SYS)-$(D):OutTCLKA-", "$(SYS)-$(D):OutTCLKA-Src-", "$(EVR):FrontUnivOut16", "TCLKA", 61}
-{"$(SYS)-$(D):OutTCLKB-", "$(SYS)-$(D):OutTCLKB-Src-", "$(EVR):FrontUnivOut17", "TCLKB", 61}
+{"$(SYS)$(D)OutFPUV0-", "$(SYS)$(D)OutFPUV0-Src-", "$(EVR)$(SEP=:)FrontUnivOut0", "UNIV0", 61}
+{"$(SYS)$(D)OutFPUV1-", "$(SYS)$(D)OutFPUV1-Src-", "$(EVR)$(SEP=:)FrontUnivOut1", "UNIV1", 61}
+{"$(SYS)$(D)OutFPUV2-", "$(SYS)$(D)OutFPUV2-Src-", "$(EVR)$(SEP=:)FrontUnivOut2", "UNIV2", 61}
+{"$(SYS)$(D)OutFPUV3-", "$(SYS)$(D)OutFPUV3-Src-", "$(EVR)$(SEP=:)FrontUnivOut3", "UNIV3", 61}
+{"$(SYS)$(D)OutBack0-", "$(SYS)$(D)OutBack0-Src-", "$(EVR)$(SEP=:)Backplane0", "RX17 (0)", 61}
+{"$(SYS)$(D)OutBack1-", "$(SYS)$(D)OutBack1-Src-", "$(EVR)$(SEP=:)Backplane1", "TX17 (1)", 61}
+{"$(SYS)$(D)OutBack2-", "$(SYS)$(D)OutBack2-Src-", "$(EVR)$(SEP=:)Backplane2", "RX18 (2)", 61}
+{"$(SYS)$(D)OutBack3-", "$(SYS)$(D)OutBack3-Src-", "$(EVR)$(SEP=:)Backplane3", "TX18 (3)", 61}
+{"$(SYS)$(D)OutBack4-", "$(SYS)$(D)OutBack4-Src-", "$(EVR)$(SEP=:)Backplane4", "RX19 (4)", 61}
+{"$(SYS)$(D)OutBack5-", "$(SYS)$(D)OutBack5-Src-", "$(EVR)$(SEP=:)Backplane5", "TX19 (5)", 61}
+{"$(SYS)$(D)OutBack6-", "$(SYS)$(D)OutBack6-Src-", "$(EVR)$(SEP=:)Backplane6", "RX20 (6)", 61}
+{"$(SYS)$(D)OutBack7-", "$(SYS)$(D)OutBack7-Src-", "$(EVR)$(SEP=:)Backplane7", "TX20 (7)", 61}
+{"$(SYS)$(D)OutTCLKA-", "$(SYS)$(D)OutTCLKA-Src-", "$(EVR)$(SEP=:)FrontUnivOut16", "TCLKA", 61}
+{"$(SYS)$(D)OutTCLKB-", "$(SYS)$(D)OutTCLKB-Src-", "$(EVR)$(SEP=:)FrontUnivOut17", "TCLKB", 61}
 }
 
 file "mrmevroutint.db"
 {{
-    ON="$(SYS)-$(D):OutInt-", OBJ="$(EVR)"
+    ON="$(SYS)$(D)OutInt-", OBJ="$(EVR)"
 }}
 
 file "evrcml.db"
 {pattern
 {PLINK, ON, ONFREQ, ONPAT, ONWFCALC, ONBT, OBJ}
-{"$(SYS)-$(D):Link-", "$(SYS)-$(D):OutTCLKA-", "$(SYS)-$(D):OutTCLKA-Freq-", "$(SYS)-$(D):OutTCLKA-Pat-", "$(SYS)-$(D):OutTCLKA-WfCalc-", "$(SYS)-$(D):OutTCLKA-BunchTrain-", "$(EVR):CML0"}
-{"$(SYS)-$(D):Link-", "$(SYS)-$(D):OutTCLKB-", "$(SYS)-$(D):OutTCLKB-Freq-", "$(SYS)-$(D):OutTCLKB-Pat-", "$(SYS)-$(D):OutTCLKB-WfCalc-", "$(SYS)-$(D):OutTCLKB-BunchTrain-", "$(EVR):CML1"}
+{"$(SYS)$(D)Link-", "$(SYS)$(D)OutTCLKA-", "$(SYS)$(D)OutTCLKA-Freq-", "$(SYS)$(D)OutTCLKA-Pat-", "$(SYS)$(D)OutTCLKA-WfCalc-", "$(SYS)$(D)OutTCLKA-BunchTrain-", "$(EVR)$(SEP=:)CML0"}
+{"$(SYS)$(D)Link-", "$(SYS)$(D)OutTCLKB-", "$(SYS)$(D)OutTCLKB-Freq-", "$(SYS)$(D)OutTCLKB-Pat-", "$(SYS)$(D)OutTCLKB-WfCalc-", "$(SYS)$(D)OutTCLKB-BunchTrain-", "$(EVR)$(SEP=:)CML1"}
 }
 
 # Pulse generators w/o a prescaler set NOPS=1
 file "evrpulser.db"
 {pattern
 {PID, P, PLINK, PN, PNDELAY, PNWIDTH, OBJ, DMAX, WMAX, PMAX, NOPS}
-{0, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
-{1, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
-{2, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
-{3, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
-{4, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{5, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{6, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{7, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{8, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{9, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{10,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{11,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{12,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{13,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{14,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{15,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{0, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{1, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{2, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{3, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{4, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{5, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{6, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{7, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{8, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{9, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{10,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{11,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{12,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{13,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{14,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{15,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
 # gate generators
-{28,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{29,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{30,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{31,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{28,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{29,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{30,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{31,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
 }
 
 # Default to 3 possible trigger mappings per pulser
 file "evrpulsermap.db"
 {pattern
 {PID, NAME, OBJ, F, EVT}
-{0, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{0, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{0, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{1, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{1, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{1, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{2, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{2, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{2, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{3, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{3, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{3, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{4, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{4, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{4, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{5, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{5, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{5, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{6, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{6, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{6, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{7, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{7, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{7, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{8, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{8, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{8, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{9, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{9, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{9, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{10,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{10,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{10,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{11,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{11,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{11,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{12,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{12,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{12,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{13,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{13,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{13,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{14,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{14,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{14,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{15,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{15,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{15,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{0, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{0, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{0, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{1, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{1, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{1, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{2, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{2, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{2, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{3, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{3, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{3, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{4, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{4, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{4, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{5, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{5, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{5, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{6, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{6, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{6, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{7, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{7, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{7, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{8, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{8, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{8, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{9, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{9, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{9, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{10,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{10,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{10,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{11,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{11,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{11,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{12,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{12,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{12,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{13,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{13,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{13,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{14,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{14,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{14,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{15,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{15,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{15,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
 # gate generators mappings
-{28,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{28,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{28,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{29,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{29,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{29,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{30,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{30,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{30,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{31,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{31,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{31,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{28,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{28,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{28,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{29,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{29,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{29,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{30,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{30,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{30,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{31,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{31,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{31,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
 }
 
 # pulser masking controls
 file "evrdcpulser.template"
 {pattern
 {PID, P, PN, OBJ}
-{0, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{1, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{2, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{3, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{4, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{5, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{6, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{7, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{8, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{9, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{10, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{11, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{12, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{13, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{14, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{15, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
+{0, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{1, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{2, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{3, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{4, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{5, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{6, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{7, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{8, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{9, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{10, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{11, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{12, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{13, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{14, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{15, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
 }
 
 file "evrin.db"
 {pattern
 {IN, INTRIG, INCODE, OBJ, DESC}
-{"$(SYS)-$(D):In0-", "$(SYS)-$(D):In0-Trig-", "$(SYS)-$(D):In0-Code-", "$(EVR):FPIn0", "IN0 (TTL)"}
-{"$(SYS)-$(D):In1-", "$(SYS)-$(D):In1-Trig-", "$(SYS)-$(D):In1-Code-", "$(EVR):FPIn1", "IN1 (TTL)"}
+{"$(SYS)$(D)In0-", "$(SYS)$(D)In0-Trig-", "$(SYS)$(D)In0-Code-", "$(EVR)$(SEP=:)FPIn0", "IN0 (TTL)"}
+{"$(SYS)$(D)In1-", "$(SYS)$(D)In1-Trig-", "$(SYS)$(D)In1-Code-", "$(EVR)$(SEP=:)FPIn1", "IN1 (TTL)"}
 }

--- a/template/evr-pcie-300dc-ess.substitutions
+++ b/template/evr-pcie-300dc-ess.substitutions
@@ -3,249 +3,249 @@
 # Macros:
 #  EVR = Card name (same as mrmEvrSetupPCI())
 #  SYS = System name (ie SR-TM)
-#  D = Device name (ie EVR:Diag2)
+#  D = Device name (ie EVR-Diag2)
 #  FEVT = Event link frequency (default 124.916 MHz)
 #
 # Record names have the general forms:
-#  $(SYS)-$(D):Signal-SD
-#  $(SYS)-$(D):SubDev-Signal-SD
+#  $(SYS)$(D)Signal-SD
+#  $(SYS)$(D)SubDev-Signal-SD
 
 file "evrbase.db"
 {
-{P="$(SYS)-$(D):", PCNT="$(SYS)-$(D):Cnt-", PLINK="$(SYS)-$(D):Link-", PRATE="$(SYS)-$(D):Rate-", PTIME="$(SYS)-$(D):Time-", OBJ="$(EVR)", OBJBUFRX="$(EVR):BUFRX", EVNT1HZ="\$(EVNT1HZ=125)", FEVT="\$(FEVT=124.916)"}
+{P="$(SYS)$(D)", PCNT="$(SYS)$(D)Cnt-", PLINK="$(SYS)$(D)Link-", PRATE="$(SYS)$(D)Rate-", PTIME="$(SYS)$(D)Time-", OBJ="$(EVR)", OBJBUFRX="$(EVR)$(SEP=:)BUFRX", EVNT1HZ="\$(EVNT1HZ=125)", FEVT="\$(FEVT=124.916)"}
 }
 
 file "databuftx.db"
 {pattern
 {P, OBJ, PROTO}
-{"$(SYS)-$(D):dbus-send-", "$(EVR):BUFTX", 1}
+{"$(SYS)$(D)dbus-send-", "$(EVR)$(SEP=:)BUFTX", 1}
 }
 
 file "evrSoftEvt.template"
 {
-{P="$(SYS)-$(D):", OBJ="$(EVR)"}
+{P="$(SYS)$(D)", OBJ="$(EVR)"}
 }
 
 file "databuftxCtrl.db"
 {pattern
 {P, OBJ}
-{"$(SYS)-$(D):Link-", "$(EVR):BUFTX"}
+{"$(SYS)$(D)Link-", "$(EVR)$(SEP=:)BUFTX"}
 }
 
 file "mrmevrbufrx.db"
 {pattern
 {P, OBJ, PROTO}
-{"$(SYS)-$(D):dbus-recv-", $(EVR):BUFRX, 0xff00}
+{"$(SYS)$(D)dbus-recv-", $(EVR)$(SEP=:)BUFRX, 0xff00}
 }
 
 file mrmSoftSeq.template {
 pattern { P, PINITSEQ, PTRIGSRC, EVG, seqNum, NELM }
-{ "$(SYS)-$(D):SoftSeq0-", "$(SYS)-$(D):SoftSeq0-InitSeq-", "$(SYS)-$(D):SoftSeq0-TrigSrc-", "$(EVR)", 0, 2047 }
-{ "$(SYS)-$(D):SoftSeq1-", "$(SYS)-$(D):SoftSeq1-InitSeq-", "$(SYS)-$(D):SoftSeq1-TrigSrc-", "$(EVR)", 1, 2047 }
-{ "$(SYS)-$(D):SoftSeq2-", "$(SYS)-$(D):SoftSeq2-InitSeq-", "$(SYS)-$(D):SoftSeq2-TrigSrc-", "$(EVR)", 2, 2047 }
+{ "$(SYS)$(D)SoftSeq0-", "$(SYS)$(D)SoftSeq0-InitSeq-", "$(SYS)$(D)SoftSeq0-TrigSrc-", "$(EVR)", 0, 2047 }
+{ "$(SYS)$(D)SoftSeq1-", "$(SYS)$(D)SoftSeq1-InitSeq-", "$(SYS)$(D)SoftSeq1-TrigSrc-", "$(EVR)", 1, 2047 }
+{ "$(SYS)$(D)SoftSeq2-", "$(SYS)$(D)SoftSeq2-InitSeq-", "$(SYS)$(D)SoftSeq2-TrigSrc-", "$(EVR)", 2, 2047 }
 }
 
 file evrSoftSeq.template {
 pattern { P, PTRIGSRC, PEVTCLKFREQ, SYSDEVTCLK, EVG, seqNum, NELM }
-{ "$(SYS)-$(D):SoftSeq0-", "$(SYS)-$(D):SoftSeq0-TrigSrc-", "$(SYS)-$(D):SoftSeq0-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", "$(EVR)", 0, 2047 }
-{ "$(SYS)-$(D):SoftSeq1-", "$(SYS)-$(D):SoftSeq1-TrigSrc-", "$(SYS)-$(D):SoftSeq1-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", "$(EVR)", 1, 2047 }
-{ "$(SYS)-$(D):SoftSeq2-", "$(SYS)-$(D):SoftSeq2-TrigSrc-", "$(SYS)-$(D):SoftSeq2-EvtClkFreq-", "$(SYS)-$(D):EvtClk-", "$(EVR)", 2, 2047 }
+{ "$(SYS)$(D)SoftSeq0-", "$(SYS)$(D)SoftSeq0-TrigSrc-", "$(SYS)$(D)SoftSeq0-EvtClkFreq-", "$(SYS)$(D)EvtClk-", "$(EVR)", 0, 2047 }
+{ "$(SYS)$(D)SoftSeq1-", "$(SYS)$(D)SoftSeq1-TrigSrc-", "$(SYS)$(D)SoftSeq1-EvtClkFreq-", "$(SYS)$(D)EvtClk-", "$(EVR)", 1, 2047 }
+{ "$(SYS)$(D)SoftSeq2-", "$(SYS)$(D)SoftSeq2-TrigSrc-", "$(SYS)$(D)SoftSeq2-EvtClkFreq-", "$(SYS)$(D)EvtClk-", "$(EVR)", 2, 2047 }
 }
 
 file "sfp.db"
 {
-{P="$(SYS)-$(D):SFP-", PPWR="$(SYS)-$(D):SFP-Pwr-", PSPEED="$(SYS)-$(D):SFP-Speed-", PDATE="$(SYS)-$(D):SFP-Date-", OBJ="$(EVR):SFP"}
+{P="$(SYS)$(D)SFP-", PPWR="$(SYS)$(D)SFP-Pwr-", PSPEED="$(SYS)$(D)SFP-Speed-", PDATE="$(SYS)$(D)SFP-Date-", OBJ="$(EVR)$(SEP=:)SFP"}
 }
 
 file "mrmevrdc.template"
 {
-{P="$(SYS)-$(D):DC-", OBJ="$(EVR)"}
+{P="$(SYS)$(D)DC-", OBJ="$(EVR)"}
 }
 
 file "evrmap.db"
 {pattern
 {NAME, OBJ, func, EVT}
-{"$(SYS)-$(D):Evt-Blink0-SP", "$(EVR)", Blink, 15}
-{"$(SYS)-$(D):Evt-Blink1-SP", "$(EVR)", Blink, 0}
-{"$(SYS)-$(D):Evt-ResetPS-SP","$(EVR)", "Reset PS", 123}
+{"$(SYS)$(D)Evt-Blink0-SP", "$(EVR)", Blink, 15}
+{"$(SYS)$(D)Evt-Blink1-SP", "$(EVR)", Blink, 0}
+{"$(SYS)$(D)Evt-ResetPS-SP","$(EVR)", "Reset PS", 123}
 }
 
 file "evrevent.db"
 {pattern
 {EN, OBJ, CODE, EVNT}
-{"$(SYS)-$(D):1hz",  "$(EVR)", 0x7d, 125}
-{"$(SYS)-$(D):EvtA", "$(EVR)", 10, 10}
-{"$(SYS)-$(D):EvtB", "$(EVR)", 11, 11}
-{"$(SYS)-$(D):EvtC", "$(EVR)", 12, 12}
-{"$(SYS)-$(D):EvtD", "$(EVR)", 13, 13}
-{"$(SYS)-$(D):EvtE", "$(EVR)", 14, 14}
-{"$(SYS)-$(D):EvtF", "$(EVR)", 15, 15}
-{"$(SYS)-$(D):EvtG", "$(EVR)", 16, 16}
-{"$(SYS)-$(D):EvtH", "$(EVR)", 17, 17}
+{"$(SYS)$(D)1hz",  "$(EVR)", 0x7d, 125}
+{"$(SYS)$(D)EvtA", "$(EVR)", 10, 10}
+{"$(SYS)$(D)EvtB", "$(EVR)", 11, 11}
+{"$(SYS)$(D)EvtC", "$(EVR)", 12, 12}
+{"$(SYS)$(D)EvtD", "$(EVR)", 13, 13}
+{"$(SYS)$(D)EvtE", "$(EVR)", 14, 14}
+{"$(SYS)$(D)EvtF", "$(EVR)", 15, 15}
+{"$(SYS)$(D)EvtG", "$(EVR)", 16, 16}
+{"$(SYS)$(D)EvtH", "$(EVR)", 17, 17}
 }
 
 file "evrscale.db"
 {pattern
 {IDX, P, SN, OBJ, MAX}
-{0, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{1, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{2, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{3, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{4, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{5, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{6, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
-{7, "$(SYS)-$(D):Link-", "$(SYS)-$(D):PS$(IDX)-", "$(EVR):PS$(IDX)", "0xffffffff"}
+{0, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{1, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{2, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{3, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{4, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{5, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{6, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
+{7, "$(SYS)$(D)Link-", "$(SYS)$(D)PS$(IDX)-", "$(EVR)$(SEP=:)PS$(IDX)", "0xffffffff"}
 }
 
 file "mrmevrout.db"
 {pattern
 {ON, ONSRC, OBJ, DESC}
-{"$(SYS)-$(D):OutInt-", "$(SYS)-$(D):OutInt-Src-", "$(EVR):Int", "Internal"}
+{"$(SYS)$(D)OutInt-", "$(SYS)$(D)OutInt-Src-", "$(EVR)$(SEP=:)Int", "Internal"}
 # default to tri-state for IFB
 pattern
 {ON, ONSRC, OBJ, DESC, DEFAULT}
-{"$(SYS)-$(D):OutFPUV00-", "$(SYS)-$(D):OutFPUV00-Src-", "$(EVR):FrontUnivOut0", "UNIV0", 61}
-{"$(SYS)-$(D):OutFPUV01-", "$(SYS)-$(D):OutFPUV01-Src-", "$(EVR):FrontUnivOut1", "UNIV1", 61}
-{"$(SYS)-$(D):OutFPUV02-", "$(SYS)-$(D):OutFPUV02-Src-", "$(EVR):FrontUnivOut2", "UNIV2", 61}
-{"$(SYS)-$(D):OutFPUV03-", "$(SYS)-$(D):OutFPUV03-Src-", "$(EVR):FrontUnivOut3", "UNIV3", 61}
-{"$(SYS)-$(D):OutFPUV04-", "$(SYS)-$(D):OutFPUV04-Src-", "$(EVR):FrontUnivOut4", "UNIV4", 61}
-{"$(SYS)-$(D):OutFPUV05-", "$(SYS)-$(D):OutFPUV05-Src-", "$(EVR):FrontUnivOut5", "UNIV5", 61}
-{"$(SYS)-$(D):OutFPUV06-", "$(SYS)-$(D):OutFPUV06-Src-", "$(EVR):FrontUnivOut6", "UNIV6", 61}
-{"$(SYS)-$(D):OutFPUV07-", "$(SYS)-$(D):OutFPUV07-Src-", "$(EVR):FrontUnivOut7", "UNIV7", 61}
-{"$(SYS)-$(D):OutFPUV08-", "$(SYS)-$(D):OutFPUV08-Src-", "$(EVR):FrontUnivOut8", "UNIV8", 61}
-{"$(SYS)-$(D):OutFPUV09-", "$(SYS)-$(D):OutFPUV09-Src-", "$(EVR):FrontUnivOut9", "UNIV9", 61}
-{"$(SYS)-$(D):OutFPUV10-", "$(SYS)-$(D):OutFPUV10-Src-", "$(EVR):FrontUnivOut10","UNIV10", 61}
-{"$(SYS)-$(D):OutFPUV11-", "$(SYS)-$(D):OutFPUV11-Src-", "$(EVR):FrontUnivOut11","UNIV11", 61}
-{"$(SYS)-$(D):OutFPUV12-", "$(SYS)-$(D):OutFPUV12-Src-", "$(EVR):FrontUnivOut12","UNIV12", 61}
-{"$(SYS)-$(D):OutFPUV13-", "$(SYS)-$(D):OutFPUV13-Src-", "$(EVR):FrontUnivOut13","UNIV13", 61}
-{"$(SYS)-$(D):OutFPUV14-", "$(SYS)-$(D):OutFPUV14-Src-", "$(EVR):FrontUnivOut14","UNIV14", 61}
-{"$(SYS)-$(D):OutFPUV15-", "$(SYS)-$(D):OutFPUV15-Src-", "$(EVR):FrontUnivOut15","UNIV15", 61}
+{"$(SYS)$(D)OutFPUV00-", "$(SYS)$(D)OutFPUV00-Src-", "$(EVR)$(SEP=:)FrontUnivOut0", "UNIV0", 61}
+{"$(SYS)$(D)OutFPUV01-", "$(SYS)$(D)OutFPUV01-Src-", "$(EVR)$(SEP=:)FrontUnivOut1", "UNIV1", 61}
+{"$(SYS)$(D)OutFPUV02-", "$(SYS)$(D)OutFPUV02-Src-", "$(EVR)$(SEP=:)FrontUnivOut2", "UNIV2", 61}
+{"$(SYS)$(D)OutFPUV03-", "$(SYS)$(D)OutFPUV03-Src-", "$(EVR)$(SEP=:)FrontUnivOut3", "UNIV3", 61}
+{"$(SYS)$(D)OutFPUV04-", "$(SYS)$(D)OutFPUV04-Src-", "$(EVR)$(SEP=:)FrontUnivOut4", "UNIV4", 61}
+{"$(SYS)$(D)OutFPUV05-", "$(SYS)$(D)OutFPUV05-Src-", "$(EVR)$(SEP=:)FrontUnivOut5", "UNIV5", 61}
+{"$(SYS)$(D)OutFPUV06-", "$(SYS)$(D)OutFPUV06-Src-", "$(EVR)$(SEP=:)FrontUnivOut6", "UNIV6", 61}
+{"$(SYS)$(D)OutFPUV07-", "$(SYS)$(D)OutFPUV07-Src-", "$(EVR)$(SEP=:)FrontUnivOut7", "UNIV7", 61}
+{"$(SYS)$(D)OutFPUV08-", "$(SYS)$(D)OutFPUV08-Src-", "$(EVR)$(SEP=:)FrontUnivOut8", "UNIV8", 61}
+{"$(SYS)$(D)OutFPUV09-", "$(SYS)$(D)OutFPUV09-Src-", "$(EVR)$(SEP=:)FrontUnivOut9", "UNIV9", 61}
+{"$(SYS)$(D)OutFPUV10-", "$(SYS)$(D)OutFPUV10-Src-", "$(EVR)$(SEP=:)FrontUnivOut10","UNIV10", 61}
+{"$(SYS)$(D)OutFPUV11-", "$(SYS)$(D)OutFPUV11-Src-", "$(EVR)$(SEP=:)FrontUnivOut11","UNIV11", 61}
+{"$(SYS)$(D)OutFPUV12-", "$(SYS)$(D)OutFPUV12-Src-", "$(EVR)$(SEP=:)FrontUnivOut12","UNIV12", 61}
+{"$(SYS)$(D)OutFPUV13-", "$(SYS)$(D)OutFPUV13-Src-", "$(EVR)$(SEP=:)FrontUnivOut13","UNIV13", 61}
+{"$(SYS)$(D)OutFPUV14-", "$(SYS)$(D)OutFPUV14-Src-", "$(EVR)$(SEP=:)FrontUnivOut14","UNIV14", 61}
+{"$(SYS)$(D)OutFPUV15-", "$(SYS)$(D)OutFPUV15-Src-", "$(EVR)$(SEP=:)FrontUnivOut15","UNIV15", 61}
 }
 
 file "mrmevroutint.db"
 {{
-    ON="$(SYS)-$(D):OutInt-", OBJ="$(EVR)"
+    ON="$(SYS)$(D)OutInt-", OBJ="$(EVR)"
 }}
 
 # Pulse generators w/o a prescaler set NOPS=1
 file "evrpulser.db"
 {pattern
 {PID, P, PLINK, PN, PNDELAY, PNWIDTH, OBJ, DMAX, WMAX, PMAX, NOPS}
-{0, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
-{1, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
-{2, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
-{3, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
-{4, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{5, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{6, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{7, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{8, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{9, "$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{10,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{11,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{12,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{13,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{14,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{15,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{0, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{1, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{2, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{3, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffffffff", "0xffff", 0}
+{4, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{5, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{6, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{7, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{8, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{9, "$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{10,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{11,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{12,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{13,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{14,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{15,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
 # gate generators
-{28,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{29,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{30,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
-{31,"$(SYS)-$(D):", "$(SYS)-$(D):Link-", "$(SYS)-$(D):DlyGen$(PID)-", "$(SYS)-$(D):DlyGen$(PID)-Delay-", "$(SYS)-$(D):DlyGen$(PID)-Width-", "$(EVR):Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{28,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{29,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{30,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
+{31,"$(SYS)$(D)", "$(SYS)$(D)Link-", "$(SYS)$(D)DlyGen$(PID)-", "$(SYS)$(D)DlyGen$(PID)-Delay-", "$(SYS)$(D)DlyGen$(PID)-Width-", "$(EVR)$(SEP=:)Pul$(PID)", "0xffffffff", "0xffff", "1", 1}
 }
 
 # Default to 3 possible trigger mappings per pulser
 file "evrpulsermap.db"
 {pattern
 {PID, NAME, OBJ, F, EVT}
-{0, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{0, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{0, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{1, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{1, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{1, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{2, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{2, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{2, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{3, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{3, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{3, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{4, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{4, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{4, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{5, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{5, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{5, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{6, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{6, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{6, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{7, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{7, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{7, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{8, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{8, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{8, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{9, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{9, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{9, "$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{10,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{10,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{10,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{11,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{11,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{11,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{12,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{12,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{12,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{13,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{13,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{13,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{14,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{14,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{14,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{15,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{15,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{15,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{0, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{0, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{0, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{1, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{1, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{1, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{2, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{2, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{2, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{3, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{3, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{3, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{4, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{4, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{4, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{5, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{5, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{5, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{6, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{6, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{6, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{7, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{7, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{7, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{8, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{8, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{8, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{9, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{9, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{9, "$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{10,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{10,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{10,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{11,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{11,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{11,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{12,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{12,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{12,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{13,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{13,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{13,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{14,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{14,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{14,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{15,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{15,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{15,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
 # gate generators mappings
-{28,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{28,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{28,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{29,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{29,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{29,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{30,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{30,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{30,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{31,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig0-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{31,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig1-SP", "$(EVR):Pul$(PID)", Trig, 0}
-{31,"$(SYS)-$(D):DlyGen$(PID)-Evt-Trig2-SP", "$(EVR):Pul$(PID)", Trig, 0}
+{28,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{28,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{28,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{29,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{29,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{29,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{30,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{30,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{30,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{31,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig0-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{31,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig1-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
+{31,"$(SYS)$(D)DlyGen$(PID)-Evt-Trig2-SP", "$(EVR)$(SEP=:)Pul$(PID)", Trig, 0}
 }
 
 # pulser masking controls
 file "evrdcpulser.template"
 {pattern
 {PID, P, PN, OBJ}
-{0, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{1, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{2, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{3, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{4, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{5, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{6, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{7, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{8, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{9, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{10, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{11, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{12, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{13, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{14, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
-{15, "$(SYS)-$(D):", "$(SYS)-$(D):DlyGen$(PID)-", "$(EVR):Pul$(PID)"}
+{0, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{1, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{2, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{3, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{4, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{5, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{6, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{7, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{8, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{9, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{10, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{11, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{12, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{13, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{14, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
+{15, "$(SYS)$(D)", "$(SYS)$(D)DlyGen$(PID)-", "$(EVR)$(SEP=:)Pul$(PID)"}
 }
 
 file "evrin.db"
 {pattern
 {IN, INTRIG, INCODE, OBJ, DESC}
-{"$(SYS)-$(D):In0-", "$(SYS)-$(D):In0-Trig-", "$(SYS)-$(D):In0-Code-", "$(EVR):FPIn0", "IN0 (TTL)"}
-{"$(SYS)-$(D):In1-", "$(SYS)-$(D):In1-Trig-", "$(SYS)-$(D):In1-Code-", "$(EVR):FPIn1", "IN1 (TTL)"}
+{"$(SYS)$(D)In0-", "$(SYS)$(D)In0-Trig-", "$(SYS)$(D)In0-Code-", "$(EVR)$(SEP=:)FPIn0", "IN0 (TTL)"}
+{"$(SYS)$(D)In1-", "$(SYS)$(D)In1-Trig-", "$(SYS)$(D)In1-Code-", "$(EVR)$(SEP=:)FPIn1", "IN1 (TTL)"}
 }


### PR DESCRIPTION
This is a significant change to the substitutions files and the startup scripts. Please review carefully before accepting this pull request.
I have attempted to maintain consistency, but there will be some changes to the PV names produced.
PV names are generated according to the ESS naming convention: Area:Device:Property
A few of the startup scripts use the $(IOC) macro for the Area name part. I have kept the macro names the same.
In most startup scripts, I have added an EVR or EVG macro to allow definition of the device ID without a separator.
The database changes are working for the EVRs at Utgård. I have modified the startup scripts in this repo, but have not tested them.
