### PR TITLE
Update EPICS startup scripts and snippets to match new database macros

### DIFF
--- a/cmds/evr_mtca_300_basis.cmd
+++ b/cmds/evr_mtca_300_basis.cmd
@@ -1,18 +1,29 @@
-require mrfioc2,2.2.0-rc5
+require mrfioc2,2.2.1rc1
 
-epicsEnvSet("ENGINEER","Han")
-epicsEnvSet("LOCATION","Table at ICS Tuna Lab")
+#- Channel Access environment configuration
 epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 
-epicsEnvSet("IOC", "MTCA")
-epicsEnvSet("DEV", "EVR")
+#- Example MACROS
+epicsEnvSet("SECSUB", "LAB-010")
+epicsEnvSet("DISDEVID", "Ctrl-EVR-001")
+epicsEnvSet("PREFIX", "$(SECSUB):$(DISDEVID):")
+epicsEnvSet("ENGINEER","Han")
+epicsEnvSet("LOCATION","Table at ICS Tuna Lab")
+
+#- EVR PCI address
+epicsEnvSet("PCIID", "0f:00.0")
 
 # Not use in this script, but it is needed for the expansion. 
 epicsEnvSet("MainEvtCODE" "14")
 
-iocshLoad("$(mrfioc2_DIR)/evr-mtca-300.iocsh", "S=$(IOC), DEV=$(DEV), PCIID=0b:00.0")
+#
+# Record names follows the template "$(P)$(R=)$(S=:)Signal-SD"
+# "P" is mandatory, "R" is optional (default empty), "S" is optional (defaul separator ":")
+# "DEV" is a unique identifier of the EVR card used by mrfioc2 device support layer
+#
+iocshLoad("$(mrfioc2_DIR)/evr-mtca-300.iocsh", "P=$(PREFIX), S=, DEV=$(DISDEVID), PCIID=$(PCIID)")
 #-iocshLoad("$(mrfioc2_DIR)/evr-mtca-300.iocsh", "S=$(IOC), DEV=$(DEV), PCIID=0b:00.0, RT=wtRT")
 
 iocInit()
 
-dbl > "${IOC}_PVs.list"
+#dbl > "${IOC}_PVs.list"

--- a/cmds/evr_mtca_300_standalone.cmd
+++ b/cmds/evr_mtca_300_standalone.cmd
@@ -1,22 +1,33 @@
-require mrfioc2,2.2.0-rc5
+require mrfioc2,2.2.1rc1
 
-epicsEnvSet("ENGINEER","Han")
-epicsEnvSet("LOCATION","Table at ICS Tuna Lab")
+#- Channel Access environment configuration
 epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
 
-epicsEnvSet("IOC", "MTCA")
-epicsEnvSet("DEV", "EVR")
+#- Example MACROS
+epicsEnvSet("SECSUB", "LAB-010")
+epicsEnvSet("DISDEVID", "Ctrl-EVR-001")
+epicsEnvSet("PREFIX", "$(SECSUB):$(DISDEVID):")
+epicsEnvSet("ENGINEER","Han")
+epicsEnvSet("LOCATION","Table at ICS Tuna Lab")
 
-# Not use in this script, but it is needed for the expansion.
+#- EVR PCI address
+epicsEnvSet("PCIID", "0f:00.0")
+
+# Not use in this script, but it is needed for the expansion. 
 epicsEnvSet("MainEvtCODE" "14")
 
-iocshLoad("$(mrfioc2_DIR)/evr-mtca-300.iocsh", "S=$(IOC), DEV=$(DEV), PCIID=0b:00.0")
+#
+# Record names follows the template "$(P)$(R=)$(S=:)Signal-SD"
+# "P" is mandatory, "R" is optional (default empty), "S" is optional (defaul separator ":")
+# "DEV" is a unique identifier of the EVR card used by mrfioc2 device support layer
+#
+iocshLoad("$(mrfioc2_DIR)/evr-mtca-300.iocsh", "P=$(PREFIX), S=, DEV=$(DISDEVID), PCIID=$(PCIID)")
 #-iocshLoad("$(mrfioc2_DIR)/evr-mtca-300.iocsh", "S=$(IOC), DEV=$(DEV), PCIID=0b:00.0, RT=wtRT")
 
 iocInit()
 
-dbl > "${IOC}_PVs.list"
+#dbl > "${IOC}_PVs.list"
 
 # The following script should be called after iocInit()
-iocshLoad("$(mrfioc2_DIR)/evr-standalone-mode.iocsh", "S=$(IOC), DEV=$(DEV)")
+iocshLoad("$(mrfioc2_DIR)/evr-standalone-mode.iocsh", "PREFIX=$(PREFIX)")
 

--- a/cmds/pbi_bpm/st-standalone.cmd
+++ b/cmds/pbi_bpm/st-standalone.cmd
@@ -1,0 +1,36 @@
+require mrfioc2,2.2.1rc1
+
+errlogInit(20000)
+
+epicsEnvSet("CONTROL_GROUP",                "LAB-BPM20")
+epicsEnvSet("AMC_DEVICE",                   "0f:00.0")
+epicsEnvSet("AMC_NAME",                     "TS-EVR-000")
+epicsEnvSet("PREFIX",                       "$(CONTROL_GROUP):$(AMC_NAME):")
+epicsEnvSet("EVENT_CLOCK"                   "88.0525")
+
+#- load MTCA support
+iocshLoad("$(mrfioc2_DIR)bpm_evr_mtca_300.iocsh", "P=$(PREFIX), R=, S=, DEV=$(AMC_NAME), PCIID=$(AMC_DEVICE)")
+
+#- After init snippets
+
+#- setup EVR clock
+afterInit(iocshLoad("$(mrfioc2_DIR)bpm_evr_mtca_tclk.iocsh", "PREFIX=$(PREFIX)"))
+
+#- setup EVR standalone mode
+afterInit(iocshLoad("$(mrfioc2_DIR)evr-standalone-mode.iocsh", "PREFIX=$(PREFIX)"))
+
+#- setup EVR triggers for BPM system
+afterInit(iocshLoad("$(mrfioc2_DIR)bpm_triggers_standalone.iocsh", "PREFIX=$(PREFIX)"))
+
+###############################################################################
+iocInit
+###############################################################################
+
+#- bugfix for EVR loosing the timestamp for 5 seconds every 7-8 hours
+dbpf $(PREFIX)DC-Tgt-SP 70
+
+#- enable the EVR
+dbpf $(PREFIX)Ena-Sel "Enabled"
+
+date
+###############################################################################

--- a/cmds/pbi_bpm/st.cmd
+++ b/cmds/pbi_bpm/st.cmd
@@ -1,0 +1,36 @@
+require mrfioc2,2.2.1rc1
+
+errlogInit(20000)
+
+epicsEnvSet("CONTROL_GROUP",                "LAB-BPM20")
+epicsEnvSet("AMC_DEVICE",                   "0f:00.0")
+epicsEnvSet("AMC_NAME",                     "TS-EVR-000")
+epicsEnvSet("PREFIX",                       "$(CONTROL_GROUP):$(AMC_NAME):")
+epicsEnvSet("EVENT_CLOCK"                   "88.0525")
+
+#- load MTCA support
+iocshLoad("$(mrfioc2_DIR)bpm_evr_mtca_300.iocsh", "P=$(PREFIX), R=, S=, DEV=$(AMC_NAME), PCIID=$(AMC_DEVICE)")
+
+#- After init snippets
+
+#- setup EVR clock
+afterInit(iocshLoad("$(mrfioc2_DIR)bpm_evr_mtca_tclk.iocsh", "PREFIX=$(PREFIX)"))
+
+
+
+
+#- setup EVR triggers for BPM system
+afterInit(iocshLoad("$(mrfioc2_DIR)bpm_triggers_init.iocsh", "PREFIX=$(PREFIX)"))
+
+###############################################################################
+iocInit
+###############################################################################
+
+#- bugfix for EVR loosing the timestamp for 5 seconds every 7-8 hours
+dbpf $(PREFIX)DC-Tgt-SP 70
+
+#- enable the EVR
+dbpf $(PREFIX)Ena-Sel "Enabled"
+
+date
+###############################################################################

--- a/cmds/rflps/evr_rflps_fim_standalone.cmd
+++ b/cmds/rflps/evr_rflps_fim_standalone.cmd
@@ -1,0 +1,71 @@
+require mrfioc2,2.2.1rc1
+
+epicsEnvSet("ENGINEER","RafaelMontano")
+epicsEnvSet("LOCATION","RFLPS_LAB")
+epicsEnvSet("EPICS_CA_MAX_ARRAY_BYTES","10000000")
+
+epicsEnvSet("SECSUB", "LAB-010")
+epicsEnvSet("DISDEVID", "RFS-EVR-001")
+epicsEnvSet("PREFIX", "$(SECSUB):$(DISDEVID):")
+
+# Not use in this script, but it is needed for the expansion.
+epicsEnvSet("MainEvtCODE" "14")
+
+#- EVR PCI address
+epicsEnvSet("PCIID", "05:00.0")
+
+iocshLoad("$(mrfioc2_DIR)/evr-mtca-300.iocsh", "P=$(PREFIX), S=, DEV=$(DISDEVID), PCIID=$(PCIID)")
+
+iocInit()
+
+# The following script should be called after iocInit()
+iocshLoad("$(mrfioc2_DIR)/evr-standalone-mode.iocsh", "PREFIX=$(PREFIX)")
+
+# Set up of UnivIO 0 as Input. Generate Code 10 locally on rising edge.
+dbpf $(PREFIX)In0-Trig-Ext-Sel "Edge"
+dbpf $(PREFIX)In0-Code-Ext-SP 10
+
+# Set up of DelayGenerator 0 to be triggered by event 14 (evr-standalone-mode).
+dbpf $(PREFIX)DlyGen0-Evt-Trig0-SP 14
+dbpf $(PREFIX)DlyGen0-Width-SP 1000
+
+# Set up of DelayGenerator 1 to be triggered by event 14 (evr-standalone-mode) with 6000us delay
+dbpf $(PREFIX)DlyGen1-Evt-Trig0-SP 14
+dbpf $(PREFIX)DlyGen1-Width-SP 1000
+dbpf $(PREFIX)DlyGen1-Delay-SP 6000
+
+# Set up of DelayGenerator 2 to be triggered by event 10 (FP input 0).
+dbpf $(PREFIX)DlyGen2-Evt-Trig0-SP 10
+dbpf $(PREFIX)DlyGen2-Width-SP 1000
+
+#- MTCA EVR Front Panel trigger from DlyGen0 (14 Hz standalone)
+dbpf $(PREFIX)OutFP0-Src-SP 0
+dbpf $(PREFIX)OutFP1-Src-SP 0
+dbpf $(PREFIX)OutFP2-Src-SP 0
+dbpf $(PREFIX)OutFP3-Src-SP 0
+
+#- Backplane triggers based on DelayGenerator 1 (delayed 14Hz)
+
+#- MTCA EVR Backplane0, RX17 (0)
+dbpf $(PREFIX)OutBack0-Src-SP 1
+
+#- MTCA EVR Backplane1, TX17 (1)
+dbpf $(PREFIX)OutBack1-Src-SP 1
+
+#- MTCA EVR Backplane2, RX18 (2)
+dbpf $(PREFIX)OutBack2-Src-SP 1
+
+#- MTCA EVR Backplane3, TX18 (3)
+dbpf $(PREFIX)OutBack3-Src-SP 1
+
+#- MTCA EVR Backplane4, RX19 (4)
+dbpf $(PREFIX)OutBack4-Src-SP 1
+
+#- MTCA EVR Backplane5, TX19 (5)
+dbpf $(PREFIX)OutBack5-Src-SP 1
+
+#- MTCA EVR Backplane6, RX20 (6)
+dbpf $(PREFIX)OutBack6-Src-SP 1
+
+#- MTCA EVR Backplane7, TX20 (7)
+dbpf $(PREFIX)OutBack7-Src-SP 1

--- a/iocsh/bpm_evr_mtca_300.iocsh
+++ b/iocsh/bpm_evr_mtca_300.iocsh
@@ -20,5 +20,7 @@ mrmEvrSetupPCI("$(DEV)",  "$(PCIID)")
 dbLoadRecords("evr-mtca-300u-ess.db","P=$(P), R=$(R=), S=$(S=:), OBJ=$(DEV), FEVT=$(EVTCLOCKRATE=88.0525)")
 iocshRun('$(SWTIMESTAMP_$(RT=woRT)=) var(evrMrmTimeNSOverflowThreshold, 100000)', "SWTIMESTAMP_wtRT=#") 
 #-
+#- EVR databuffer
+dbLoadRecords("evr-databuffer-ess.db","PREFIX=$(P)$(R=)$(S=:)")
 #- Don't forget the new line
 

--- a/iocsh/bpm_evr_mtca_tclk.iocsh
+++ b/iocsh/bpm_evr_mtca_tclk.iocsh
@@ -1,0 +1,27 @@
+# EVR clock configuration
+
+#- send event clock over backplane clock line TCLKB
+#- MCH should be configured to send the clock back to the AMCs over TCLKA
+dbpf $(PREFIX)OutTCLKB-Src-SP 63
+dbpf $(PREFIX)OutTCLKB-Ena-Sel 1
+dbpf $(PREFIX)OutTCLKB-Pwr-Sel 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.BF 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.BE 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.BD 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.BC 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.BB 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.BA 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.B9 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.B8 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.B7 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.B6 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.B5 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.B4 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.B3 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.B2 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.B1 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low00_15-SP.B0 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low16_31-SP.BF 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low16_31-SP.BE 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low16_31-SP.BD 1
+dbpf $(PREFIX)OutTCLKB-Pat-Low16_31-SP.BC 1

--- a/iocsh/bpm_triggers_init.iocsh
+++ b/iocsh/bpm_triggers_init.iocsh
@@ -1,0 +1,33 @@
+# EVR triggers for BPM system
+
+#- BPM uses these backplane trigger lines
+epicsEnvSet("ROI_START_EVENT"               "12")
+epicsEnvSet("ROI_END_EVENT"                 "13")
+epicsEnvSet("ACQUISITION_EVENT"             "10")
+epicsEnvSet("PULSE_WIDTH"                   "1")
+
+# BPM acquisition start
+dbpf $(PREFIX)DlyGen0-Evt-Trig0-SP $(ACQUISITION_EVENT)
+dbpf $(PREFIX)DlyGen0-Width-SP $(PULSE_WIDTH)
+dbpf $(PREFIX)DlyGen0-Delay-SP 0
+#- backplane 0 line
+dbpf $(PREFIX)OutBack0-Src-SP 0
+
+# BPM pulse (ROI) start
+dbpf $(PREFIX)DlyGen1-Evt-Trig0-SP $(ROI_START_EVENT)
+dbpf $(PREFIX)DlyGen1-Width-SP $(PULSE_WIDTH)
+dbpf $(PREFIX)DlyGen1-Delay-SP 0
+#- backplane 1 line
+dbpf $(PREFIX)OutBack1-Src-SP 1
+
+# BPM pulse (ROI) end
+dbpf $(PREFIX)DlyGen2-Evt-Trig0-SP $(ROI_END_EVENT)
+dbpf $(PREFIX)DlyGen2-Width-SP $(PULSE_WIDTH)
+dbpf $(PREFIX)DlyGen2-Delay-SP 0
+#- backplane 2 line
+dbpf $(PREFIX)OutBack2-Src-SP 2
+
+#- debug front panel outputs
+dbpf $(PREFIX)OutFP0-Src-SP 0
+dbpf $(PREFIX)OutFP1-Src-SP 1
+dbpf $(PREFIX)OutFP2-Src-SP 2

--- a/iocsh/bpm_triggers_standalone.iocsh
+++ b/iocsh/bpm_triggers_standalone.iocsh
@@ -1,0 +1,36 @@
+# EVR triggers for BPM system
+
+#- BPM uses these backplane trigger lines
+epicsEnvSet("ROI_START_EVENT"               "12")
+epicsEnvSet("ROI_END_EVENT"                 "13")
+epicsEnvSet("ACQUISITION_EVENT"             "10")
+epicsEnvSet("PULSE_WIDTH"                   "1")
+
+#- Generate different triggers from same event
+epicsEnvSet("SEQUENCER_EVENT"               "14")
+
+# BPM acquisition start
+dbpf $(PREFIX)DlyGen0-Evt-Trig0-SP $(SEQUENCER_EVENT)
+dbpf $(PREFIX)DlyGen0-Width-SP $(PULSE_WIDTH)
+dbpf $(PREFIX)DlyGen0-Delay-SP 0
+#- backplane 0 line
+dbpf $(PREFIX)OutBack0-Src-SP 0
+
+# BPM pulse (ROI) start
+dbpf $(PREFIX)DlyGen1-Evt-Trig0-SP $(SEQUENCER_EVENT)
+dbpf $(PREFIX)DlyGen1-Width-SP $(PULSE_WIDTH)
+dbpf $(PREFIX)DlyGen1-Delay-SP 500
+#- backplane 1 line
+dbpf $(PREFIX)OutBack1-Src-SP 1
+
+# BPM pulse (ROI) end
+dbpf $(PREFIX)DlyGen2-Evt-Trig0-SP $(SEQUENCER_EVENT)
+dbpf $(PREFIX)DlyGen2-Width-SP $(PULSE_WIDTH)
+dbpf $(PREFIX)DlyGen2-Delay-SP 2500
+#- backplane 2 line
+dbpf $(PREFIX)OutBack2-Src-SP 2
+
+#- debug front panel outputs
+dbpf $(PREFIX)OutFP0-Src-SP 0
+dbpf $(PREFIX)OutFP1-Src-SP 1
+dbpf $(PREFIX)OutFP2-Src-SP 2

--- a/iocsh/configure_sequencer_14Hz.bash
+++ b/iocsh/configure_sequencer_14Hz.bash
@@ -2,25 +2,25 @@
 # Bash script to configure the EVG/EVR sequencer
 # All values in us
 # Record names have the general forms:
-# $(SYS)-$(D):Signal-SD
-# $(SYS)-$(D):SubDev-Signal-SD
+# $(P)$(R)$(S=:)Signal-SD
+# $(P)$(R)$(S=:)SubDev-Signal-SD
+# 
+# PREFIX should be $(P)$(R)$(S=:) 
+#
 
-SYS="$1"
-DEV="$2"
-
-PREFIX="${SYS}-${DEV}"
+PREFIX="$1"
 CAPUT="caput"
 EventCode=14
 EndOfSeqEvent=127
 
 if hash ${CAPUT} 2>/dev/null ; then
     # Event code 14 (14 Hz), 127 is the end of sequence
-    ${CAPUT} -a ${PREFIX}:SoftSeq0-EvtCode-SP 2 ${EventCode} ${EndOfSeqEvent}
+    ${CAPUT} -a ${PREFIX}SoftSeq0-EvtCode-SP 2 ${EventCode} ${EndOfSeqEvent} > /dev/null
     # Defining time at which the event codes are sent in us
-    ${CAPUT} -a ${PREFIX}:SoftSeq0-Timestamp-SP 2 0 1
-    
+    ${CAPUT} -a ${PREFIX}SoftSeq0-Timestamp-SP 2 0 1 > /dev/null
+
     # Commit the sequence to HW
-    ${CAPUT} ${PREFIX}:SoftSeq0-Commit-Cmd 1
+    ${CAPUT} ${PREFIX}SoftSeq0-Commit-Cmd 1 > /dev/null
 else
     printf "\n>>>> We cannot run $0\n";
     printf "     because we cannot find $CAPUT in the system\n"

--- a/iocsh/evr-mtca-init.iocsh
+++ b/iocsh/evr-mtca-init.iocsh
@@ -5,7 +5,7 @@
 # ====================================
 
 mrmEvrSetupPCI("$(DEV)", $(PCIID))
-dbLoadRecords("evr-mtca-300u-ess.db","EVR=$(DEV), SYS=$(IOC), D=$(DEV), FEVT=$(ESSEvtClockRate)")
+dbLoadRecords("evr-mtca-300u-ess.db","P=$(P), R=$(R), S=$(S=:), OBJ=$(DEV), FEVT=$(EVTCLOCKRATE=88.0525)")
 
 # needed with software timestamp [ns] source w/o RT thread scheduling
 var evrMrmTimeNSOverflowThreshold 500000000

--- a/iocsh/evr-standalone-mode.iocsh
+++ b/iocsh/evr-standalone-mode.iocsh
@@ -1,31 +1,28 @@
 #- ###   ESS EVR Standalone Mode Configuration iocsh     ###
 #- ####################################################
-#- >> Mandatory
-#- S            -  System name for Record 
-#- DEV          -  Record names have the general forms:
-#                  $(S)-$(DEV):Signal-SD
-#                  $(S)-$(DEV):SubDev-Signal-SD
+#- Record names have the general forms:
+#-      $(P)$(R)$(S=:)Signal-SD
+#-      $(P)$(R)$(S=:)SubDev-Signal-SD
+#- PREFIX should be $(P)$(R)$(S=:) 
 #- ####################################################
-#- 
-#- iocshLoad("$(mrfioc2_DIR)/evr-standalone-mode.iocsh", "S=$(IOC), DEV=$(DEV)")
 #- WARNING : THIS SCRIPT should be called after iocInit
 #- 
 #- Get current time from system clock
-dbpf $(S)-$(DEV):TimeSrc-Sel "Sys. Clock"
+dbpf $(PREFIX)TimeSrc-Sel "Sys. Clock"
 #- Set delay compensation to 70 ns, needed to avoid timesptamp issue
-dbpf $(S)-$(DEV):DC-Tgt-SP 70
+dbpf $(PREFIX)DC-Tgt-SP 70
 #- Set up the prescaler that will trigger the sequencer at 14 Hz
-dbpf $(S)-$(DEV):PS0-Div-SP 6289464
+dbpf $(PREFIX)PS0-Div-SP 6289464
 #- Set up the sequencer
 #- Set the runmode to normal, so that the sequencer re-arms after it finishes running
-dbpf $(S)-$(DEV):SoftSeq0-RunMode-Sel "Normal"
+dbpf $(PREFIX)SoftSeq0-RunMode-Sel "Normal"
 #- Set the trigger of the sequencer as prescaler 0
-dbpf $(S)-$(DEV):SoftSeq0-TrigSrc-2-Sel "Prescaler 0"
+dbpf $(PREFIX)SoftSeq0-TrigSrc-2-Sel "Prescaler 0"
 #- Set the EGU (msec) for the delay
-dbpf $(S)-$(DEV):SoftSeq0-TsResolution-Sel "uSec"
+dbpf $(PREFIX)SoftSeq0-TsResolution-Sel "uSec"
 #- Attach the soft sequence to a specific hardware sequence
-dbpf $(S)-$(DEV):SoftSeq0-Load-Cmd 1
+dbpf $(PREFIX)SoftSeq0-Load-Cmd 1
 #- Enable the sequencer
-dbpf $(S)-$(DEV):SoftSeq0-Enable-Cmd 1
+dbpf $(PREFIX)SoftSeq0-Enable-Cmd 1
 #-
-system("/bin/bash $(mrfioc2_DIR)configure_sequencer_14Hz.bash $(S) $(DEV)")
+system("/bin/bash $(mrfioc2_DIR)configure_sequencer_14Hz.bash $(PREFIX)")


### PR DESCRIPTION
Updated iocsh snippets to match the new macros of the `evr-mtca-300u-ess.db`:
- iocsh/evr-mtca-300.iocsh
- iocsh/evr-mtca-init.iocsh
- iocsh/evr-standalone-mode.iocsh

Updated the bash script that sets up the sequencer array PVs to use new macros and suppress terminal output:
- iocsh/configure_sequencer_14Hz.bash

Added new examples and new snippets for BPM systems and RFLPS Fast Interlock Module